### PR TITLE
feat: add loading spinners to API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "chalk": "5.6.2",
         "commander": "14.0.2",
         "marked": "15.0.12",
-        "marked-terminal": "7.3.0"
+        "marked-terminal": "7.3.0",
+        "yocto-spinner": "1.0.0"
       },
       "bin": {
         "ol": "dist/index.js"
@@ -2172,6 +2173,33 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yocto-spinner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.0.0.tgz",
+      "integrity": "sha512-VPX8P/+Z2Fnpx8PC/JELbxp3QRrBxjAekio6yulGtA5gKt9YyRc5ycCb+NHgZCbZ0kx9KxwZp7gC6UlrCcCdSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "chalk": "5.6.2",
     "commander": "14.0.2",
     "marked": "15.0.12",
-    "marked-terminal": "7.3.0"
+    "marked-terminal": "7.3.0",
+    "yocto-spinner": "1.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.12",

--- a/src/__tests__/spinner.test.ts
+++ b/src/__tests__/spinner.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { withSpinner, LoadingSpinner } from "../lib/spinner.js";
+
+const mockSpinnerInstance = {
+	start: vi.fn().mockReturnThis(),
+	success: vi.fn(),
+	error: vi.fn(),
+	stop: vi.fn(),
+};
+
+vi.mock("yocto-spinner", () => ({
+	default: vi.fn(() => mockSpinnerInstance),
+}));
+
+vi.mock("chalk", () => ({
+	default: {
+		green: (text: string) => text,
+		yellow: (text: string) => text,
+		blue: (text: string) => text,
+		red: (text: string) => text,
+	},
+}));
+
+describe("withSpinner", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.OL_SPINNER;
+		delete process.env.CI;
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: true,
+			configurable: true,
+		});
+		process.argv = ["node", "ol"];
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("handles successful operations", async () => {
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue" },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).toHaveBeenCalled();
+		expect(mockSpinnerInstance.stop).toHaveBeenCalled();
+		expect(mockSpinnerInstance.error).not.toHaveBeenCalled();
+	});
+
+	it("handles failed operations", async () => {
+		await expect(
+			withSpinner({ text: "Testing...", color: "blue" }, async () => {
+				throw new Error("test error");
+			}),
+		).rejects.toThrow("test error");
+
+		expect(mockSpinnerInstance.start).toHaveBeenCalled();
+		expect(mockSpinnerInstance.error).toHaveBeenCalled();
+		expect(mockSpinnerInstance.stop).not.toHaveBeenCalled();
+	});
+
+	it("skips spinner when noSpinner option is true", async () => {
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue", noSpinner: true },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).not.toHaveBeenCalled();
+	});
+
+	it("skips spinner when OL_SPINNER=false", async () => {
+		process.env.OL_SPINNER = "false";
+
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue" },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).not.toHaveBeenCalled();
+	});
+
+	it("skips spinner in CI environment", async () => {
+		process.env.CI = "true";
+
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue" },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).not.toHaveBeenCalled();
+	});
+
+	it("skips spinner when not in TTY", async () => {
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: false,
+			configurable: true,
+		});
+
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue" },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).not.toHaveBeenCalled();
+	});
+
+	it("skips spinner with --json flag", async () => {
+		process.argv = ["node", "ol", "search", "--json"];
+
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue" },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).not.toHaveBeenCalled();
+	});
+
+	it("skips spinner with --ndjson flag", async () => {
+		process.argv = ["node", "ol", "search", "--ndjson"];
+
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue" },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).not.toHaveBeenCalled();
+	});
+
+	it("skips spinner with --no-spinner flag", async () => {
+		process.argv = ["node", "ol", "auth", "status", "--no-spinner"];
+
+		const result = await withSpinner(
+			{ text: "Testing...", color: "blue" },
+			async () => "success",
+		);
+
+		expect(result).toBe("success");
+		expect(mockSpinnerInstance.start).not.toHaveBeenCalled();
+	});
+});
+
+describe("LoadingSpinner", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.OL_SPINNER;
+		delete process.env.CI;
+		Object.defineProperty(process.stdout, "isTTY", {
+			value: true,
+			configurable: true,
+		});
+		process.argv = ["node", "ol"];
+	});
+
+	it("starts and stops", () => {
+		const spinner = new LoadingSpinner();
+		spinner.start({ text: "Testing...", color: "blue" });
+		expect(mockSpinnerInstance.start).toHaveBeenCalled();
+
+		spinner.stop();
+		expect(mockSpinnerInstance.stop).toHaveBeenCalled();
+	});
+
+	it("shows success message", () => {
+		const spinner = new LoadingSpinner();
+		spinner.start({ text: "Testing...", color: "blue" });
+		spinner.succeed("Done");
+		expect(mockSpinnerInstance.success).toHaveBeenCalledWith("✓ Done");
+	});
+
+	it("shows failure message", () => {
+		const spinner = new LoadingSpinner();
+		spinner.start({ text: "Testing...", color: "blue" });
+		spinner.fail("Failed");
+		expect(mockSpinnerInstance.error).toHaveBeenCalledWith("✗ Failed");
+	});
+
+	it("handles multiple stop calls gracefully", () => {
+		const spinner = new LoadingSpinner();
+		spinner.start({ text: "Testing...", color: "blue" });
+		spinner.stop();
+		spinner.stop();
+		expect(mockSpinnerInstance.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("handles succeed/fail without starting", () => {
+		const spinner = new LoadingSpinner();
+		spinner.succeed("Test");
+		spinner.fail("Test");
+		expect(mockSpinnerInstance.success).not.toHaveBeenCalled();
+		expect(mockSpinnerInstance.error).not.toHaveBeenCalled();
+	});
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ program
 	.name("ol")
 	.version("0.1.0")
 	.description("CLI for the Outline wiki/knowledge base API")
+	.option("--no-spinner", "Disable loading animations")
 	.addHelpText(
 		"after",
 		`

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,23 @@
 import { getApiToken, getBaseUrl } from "./auth.js";
+import { type SpinnerOptions, withSpinner } from "./spinner.js";
+
+const SPINNER_MESSAGES: Record<string, SpinnerOptions> = {
+	"auth.info": { text: "Checking authentication...", color: "blue" },
+	"documents.search": { text: "Searching documents...", color: "blue" },
+	"documents.list": { text: "Loading documents...", color: "blue" },
+	"documents.info": { text: "Loading document...", color: "blue" },
+	"documents.create": { text: "Creating document...", color: "green" },
+	"documents.update": { text: "Updating document...", color: "yellow" },
+	"documents.delete": { text: "Deleting document...", color: "yellow" },
+	"documents.move": { text: "Moving document...", color: "yellow" },
+	"documents.archive": { text: "Archiving document...", color: "yellow" },
+	"documents.unarchive": { text: "Unarchiving document...", color: "yellow" },
+	"collections.list": { text: "Loading collections...", color: "blue" },
+	"collections.info": { text: "Loading collection...", color: "blue" },
+	"collections.create": { text: "Creating collection...", color: "green" },
+	"collections.update": { text: "Updating collection...", color: "yellow" },
+	"collections.delete": { text: "Deleting collection...", color: "yellow" },
+};
 
 export interface Pagination {
 	offset: number;
@@ -27,27 +46,34 @@ export async function apiRequest<T>(
 	path: string,
 	body: object = {},
 ): Promise<PaginatedResult<T>> {
-	const baseUrl = getBaseUrl();
-	const token = getApiToken();
+	const spinnerOpts = SPINNER_MESSAGES[path] || {
+		text: "Loading...",
+		color: "blue" as const,
+	};
 
-	const res = await fetch(`${baseUrl}/api/${path}`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${token}`,
-		},
-		body: JSON.stringify(body),
+	return withSpinner(spinnerOpts, async () => {
+		const baseUrl = getBaseUrl();
+		const token = getApiToken();
+
+		const res = await fetch(`${baseUrl}/api/${path}`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify(body),
+		});
+
+		if (!res.ok) {
+			let message = `API error: ${res.status} ${res.statusText}`;
+			try {
+				const err = (await res.json()) as ApiError;
+				if (err.message) message = `API error: ${err.message}`;
+			} catch {}
+			throw new Error(message);
+		}
+
+		const json = (await res.json()) as ApiResponse<T>;
+		return { data: json.data, pagination: json.pagination };
 	});
-
-	if (!res.ok) {
-		let message = `API error: ${res.status} ${res.statusText}`;
-		try {
-			const err = (await res.json()) as ApiError;
-			if (err.message) message = `API error: ${err.message}`;
-		} catch {}
-		throw new Error(message);
-	}
-
-	const json = (await res.json()) as ApiResponse<T>;
-	return { data: json.data, pagination: json.pagination };
 }

--- a/src/lib/spinner.ts
+++ b/src/lib/spinner.ts
@@ -1,0 +1,76 @@
+import yoctoSpinner from "yocto-spinner";
+import chalk from "chalk";
+
+export interface SpinnerOptions {
+	text: string;
+	color?: "green" | "yellow" | "blue" | "red";
+	noSpinner?: boolean;
+}
+
+function shouldDisableSpinner(): boolean {
+	if (process.env.OL_SPINNER === "false") return true;
+	if (process.env.CI) return true;
+
+	const args = process.argv;
+	if (
+		args.includes("--json") ||
+		args.includes("--ndjson") ||
+		args.includes("--no-spinner")
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+export class LoadingSpinner {
+	private spinnerInstance: ReturnType<typeof yoctoSpinner> | null = null;
+
+	start(options: SpinnerOptions) {
+		if (!process.stdout.isTTY || options.noSpinner || shouldDisableSpinner()) {
+			return this;
+		}
+
+		const colorFn = chalk[options.color || "blue"];
+		this.spinnerInstance = yoctoSpinner({ text: colorFn(options.text) });
+		this.spinnerInstance.start();
+		return this;
+	}
+
+	succeed(text?: string) {
+		if (this.spinnerInstance) {
+			this.spinnerInstance.success(text ? chalk.green(`✓ ${text}`) : undefined);
+			this.spinnerInstance = null;
+		}
+	}
+
+	fail(text?: string) {
+		if (this.spinnerInstance) {
+			this.spinnerInstance.error(text ? chalk.red(`✗ ${text}`) : undefined);
+			this.spinnerInstance = null;
+		}
+	}
+
+	stop() {
+		if (this.spinnerInstance) {
+			this.spinnerInstance.stop();
+			this.spinnerInstance = null;
+		}
+	}
+}
+
+export async function withSpinner<T>(
+	options: SpinnerOptions,
+	asyncOperation: () => Promise<T>,
+): Promise<T> {
+	const spinner = new LoadingSpinner().start(options);
+
+	try {
+		const result = await asyncOperation();
+		spinner.stop();
+		return result;
+	} catch (error) {
+		spinner.fail();
+		throw error;
+	}
+}


### PR DESCRIPTION
Add NPM-style loading spinners using yocto-spinner to all CLI API calls. The spinners are context-aware with semantic colors: blue for reads, green for creates, yellow for updates/deletes. Automatically disabled in CI, non-TTY, and JSON output modes. All existing tests pass plus 14 new spinner tests.