### PR TITLE
feat: add fuzzy reference resolution

### DIFF
--- a/src/commands/collection.ts
+++ b/src/commands/collection.ts
@@ -7,6 +7,7 @@ import {
 	outputItem,
 	outputList,
 } from "../lib/output.js";
+import { resolveCollectionId } from "../lib/refs.js";
 
 interface Collection {
 	id: string;
@@ -68,11 +69,14 @@ export function registerCollectionCommand(program: Command): void {
 
 	col
 		.command("get <id>")
-		.description("Get collection details")
+		.description("Get collection details by ID or name")
 		.option("--json", "Output JSON")
 		.option("--full", "Include all fields in JSON output")
 		.action(async (id: string, opts) => {
-			const { data } = await apiRequest<Collection>("collections.info", { id });
+			const resolvedId = await resolveCollectionId(id);
+			const { data } = await apiRequest<Collection>("collections.info", {
+				id: resolvedId,
+			});
 			outputItem(data, formatCollection, essentialKeys, getOutputOptions(opts));
 		});
 
@@ -107,7 +111,8 @@ export function registerCollectionCommand(program: Command): void {
 		.option("--color <hex>", "New color")
 		.option("--json", "Output JSON")
 		.action(async (id: string, opts) => {
-			const body: Record<string, unknown> = { id };
+			const resolvedId = await resolveCollectionId(id);
+			const body: Record<string, unknown> = { id: resolvedId };
 			if (opts.name) body.name = opts.name;
 			if (opts.description) body.description = opts.description;
 			if (opts.color) body.color = opts.color;
@@ -136,7 +141,8 @@ export function registerCollectionCommand(program: Command): void {
 				);
 				process.exit(1);
 			}
-			await apiRequest("collections.delete", { id });
+			const resolvedId = await resolveCollectionId(id);
+			await apiRequest("collections.delete", { id: resolvedId });
 			console.log("Deleted.");
 		});
 }

--- a/src/commands/collection.ts
+++ b/src/commands/collection.ts
@@ -7,7 +7,7 @@ import {
 	outputItem,
 	outputList,
 } from "../lib/output.js";
-import { resolveCollectionId } from "../lib/refs.js";
+import { resolveCollectionId, resolveCollectionRef } from "../lib/refs.js";
 
 interface Collection {
 	id: string;
@@ -73,10 +73,17 @@ export function registerCollectionCommand(program: Command): void {
 		.option("--json", "Output JSON")
 		.option("--full", "Include all fields in JSON output")
 		.action(async (id: string, opts) => {
-			const resolvedId = await resolveCollectionId(id);
-			const { data } = await apiRequest<Collection>("collections.info", {
-				id: resolvedId,
-			});
+			const resolved = await resolveCollectionRef(id);
+			// If resolved from name search (collections.list), some fields may be missing
+			let data: Collection;
+			if (resolved.documentCount !== undefined) {
+				data = resolved as Collection;
+			} else {
+				const response = await apiRequest<Collection>("collections.info", {
+					id: resolved.id,
+				});
+				data = response.data;
+			}
 			outputItem(data, formatCollection, essentialKeys, getOutputOptions(opts));
 		});
 

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -11,7 +11,11 @@ import {
 	outputItem,
 	outputList,
 } from "../lib/output.js";
-import { resolveCollectionId, resolveDocumentId } from "../lib/refs.js";
+import {
+	resolveCollectionId,
+	resolveDocumentId,
+	resolveDocumentRef,
+} from "../lib/refs.js";
 
 interface Document {
 	id: string;
@@ -130,10 +134,17 @@ export function registerDocumentCommand(program: Command): void {
 		.option("--json", "Output JSON")
 		.option("--full", "Include all fields in JSON output")
 		.action(async (id: string, opts) => {
-			const resolvedId = await resolveDocumentId(id);
-			const { data } = await apiRequest<Document>("documents.info", {
-				id: resolvedId,
-			});
+			const resolved = await resolveDocumentRef(id);
+			// If resolved from name search (documents.list), text may be missing
+			let data: Document;
+			if (resolved.text !== undefined) {
+				data = resolved as Document;
+			} else {
+				const response = await apiRequest<Document>("documents.info", {
+					id: resolved.id,
+				});
+				data = response.data;
+			}
 
 			const outputOpts = getOutputOptions(opts);
 			if (outputOpts.json) {
@@ -148,11 +159,8 @@ export function registerDocumentCommand(program: Command): void {
 		.command("open <id>")
 		.description("Open a document in the browser")
 		.action(async (id: string) => {
-			const resolvedId = await resolveDocumentId(id);
-			const { data } = await apiRequest<Document>("documents.info", {
-				id: resolvedId,
-			});
-			const fullUrl = `${getBaseUrl()}${data.url}`;
+			const resolved = await resolveDocumentRef(id);
+			const fullUrl = `${getBaseUrl()}${resolved.url}`;
 			openInBrowser(fullUrl);
 			console.log(chalk.dim(`Opened: ${fullUrl}`));
 		});

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -11,6 +11,7 @@ import {
 	outputItem,
 	outputList,
 } from "../lib/output.js";
+import { resolveCollectionId, resolveDocumentId } from "../lib/refs.js";
 
 interface Document {
 	id: string;
@@ -34,16 +35,6 @@ const essentialKeys: (keyof Document)[] = [
 	"collectionId",
 	"updatedAt",
 ];
-
-function resolveId(input: string): string {
-	// If it looks like a URL, extract the slug suffix
-	const parts = input.replace(/\/$/, "").split("/");
-	const last = parts[parts.length - 1];
-	// Outline URL IDs are the part after the last hyphen in the slug
-	const match = last.match(/-([a-zA-Z0-9]+)$/);
-	if (match) return match[1];
-	return input;
-}
 
 function formatDoc(doc: Document): string {
 	const title = chalk.bold(doc.title);
@@ -95,7 +86,7 @@ export function registerDocumentCommand(program: Command): void {
 	doc
 		.command("list")
 		.description("List documents")
-		.option("--collection <id>", "Filter by collection ID")
+		.option("--collection <ref>", "Filter by collection ID or name")
 		.option("--limit <n>", "Max results", "25")
 		.option("--offset <n>", "Pagination offset", "0")
 		.option(
@@ -114,7 +105,9 @@ export function registerDocumentCommand(program: Command): void {
 				sort: opts.sort,
 				direction: opts.direction,
 			};
-			if (opts.collection) body.collectionId = opts.collection;
+			if (opts.collection) {
+				body.collectionId = await resolveCollectionId(opts.collection);
+			}
 
 			const { data, pagination } = await apiRequest<Document[]>(
 				"documents.list",
@@ -132,13 +125,14 @@ export function registerDocumentCommand(program: Command): void {
 
 	doc
 		.command("get <id>")
-		.description("Get a document by URL ID or ID")
+		.description("Get a document by ID, URL, or name")
 		.option("--raw", "Output raw markdown without terminal formatting")
 		.option("--json", "Output JSON")
 		.option("--full", "Include all fields in JSON output")
 		.action(async (id: string, opts) => {
+			const resolvedId = await resolveDocumentId(id);
 			const { data } = await apiRequest<Document>("documents.info", {
-				id: resolveId(id),
+				id: resolvedId,
 			});
 
 			const outputOpts = getOutputOptions(opts);
@@ -154,8 +148,9 @@ export function registerDocumentCommand(program: Command): void {
 		.command("open <id>")
 		.description("Open a document in the browser")
 		.action(async (id: string) => {
+			const resolvedId = await resolveDocumentId(id);
 			const { data } = await apiRequest<Document>("documents.info", {
-				id: resolveId(id),
+				id: resolvedId,
 			});
 			const fullUrl = `${getBaseUrl()}${data.url}`;
 			openInBrowser(fullUrl);
@@ -166,15 +161,16 @@ export function registerDocumentCommand(program: Command): void {
 		.command("create")
 		.description("Create a document")
 		.requiredOption("--title <title>", "Document title")
-		.requiredOption("--collection <id>", "Collection ID")
+		.requiredOption("--collection <ref>", "Collection ID or name")
 		.option("--text <text>", "Document body (markdown)")
 		.option("--file <path>", "Read markdown from file")
 		.option("--publish", "Publish immediately")
 		.option("--json", "Output JSON")
 		.action(async (opts) => {
+			const collectionId = await resolveCollectionId(opts.collection);
 			const body: Record<string, unknown> = {
 				title: opts.title,
-				collectionId: opts.collection,
+				collectionId,
 			};
 
 			const text = readTextInput(opts);
@@ -201,7 +197,8 @@ export function registerDocumentCommand(program: Command): void {
 		.option("--file <path>", "Read markdown from file")
 		.option("--json", "Output JSON")
 		.action(async (id: string, opts) => {
-			const body: Record<string, unknown> = { id: resolveId(id) };
+			const resolvedId = await resolveDocumentId(id);
+			const body: Record<string, unknown> = { id: resolvedId };
 
 			const rawText = readTextInput(opts);
 			if (rawText && !opts.title) {
@@ -240,18 +237,21 @@ export function registerDocumentCommand(program: Command): void {
 				);
 				process.exit(1);
 			}
-			await apiRequest("documents.delete", { id: resolveId(id) });
+			const resolvedId = await resolveDocumentId(id);
+			await apiRequest("documents.delete", { id: resolvedId });
 			console.log("Deleted.");
 		});
 
 	doc
 		.command("move <id>")
 		.description("Move a document to another collection")
-		.requiredOption("--collection <id>", "Target collection ID")
+		.requiredOption("--collection <ref>", "Target collection ID or name")
 		.action(async (id: string, opts) => {
+			const resolvedId = await resolveDocumentId(id);
+			const collectionId = await resolveCollectionId(opts.collection);
 			await apiRequest("documents.move", {
-				id: resolveId(id),
-				collectionId: opts.collection,
+				id: resolvedId,
+				collectionId,
 			});
 			console.log("Moved.");
 		});
@@ -260,7 +260,8 @@ export function registerDocumentCommand(program: Command): void {
 		.command("archive <id>")
 		.description("Archive a document")
 		.action(async (id: string) => {
-			await apiRequest("documents.archive", { id: resolveId(id) });
+			const resolvedId = await resolveDocumentId(id);
+			await apiRequest("documents.archive", { id: resolvedId });
 			console.log("Archived.");
 		});
 
@@ -268,7 +269,8 @@ export function registerDocumentCommand(program: Command): void {
 		.command("unarchive <id>")
 		.description("Unarchive a document")
 		.action(async (id: string) => {
-			await apiRequest("documents.unarchive", { id: resolveId(id) });
+			const resolvedId = await resolveDocumentId(id);
+			await apiRequest("documents.unarchive", { id: resolvedId });
 			console.log("Unarchived.");
 		});
 }

--- a/src/lib/refs.test.ts
+++ b/src/lib/refs.test.ts
@@ -115,6 +115,42 @@ describe("resolveDocumentRef", () => {
 		);
 	});
 
+	it("shows urlId in ambiguous error suggestions for documents", async () => {
+		const mockDocs = [
+			{ id: "1", title: "Engineering Guide", urlId: "eng-guide-abc" },
+			{ id: "2", title: "Engineering Handbook", urlId: "eng-handbook-xyz" },
+		];
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found"))
+			.mockResolvedValueOnce({ data: mockDocs });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		try {
+			await resolveDocumentRef("engineering");
+		} catch (error) {
+			const message = (error as Error).message;
+			expect(message).toContain("eng-guide-abc");
+			expect(message).toContain("eng-handbook-xyz");
+			expect(message).not.toContain('"1"'); // should not show internal id
+			return;
+		}
+		expect.fail("Expected error to be thrown");
+	});
+
+	it("treats multiple exact name matches as ambiguous", async () => {
+		const mockDocs = [
+			{ id: "1", title: "Meeting Notes", urlId: "meeting-notes-abc" },
+			{ id: "2", title: "Meeting Notes", urlId: "meeting-notes-xyz" },
+		];
+		// "meeting notes" has spaces, doesn't look like an ID
+		mockApiRequest.mockResolvedValueOnce({ data: mockDocs });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		await expect(resolveDocumentRef("meeting notes")).rejects.toThrow(
+			/Ambiguous Document reference.*Multiple items have this exact name/,
+		);
+	});
+
 	it("throws not found error when no matches", async () => {
 		const mockDocs = [{ id: "1", title: "Engineering Guide", urlId: "eng-1" }];
 		// "nonexistent" is 11 chars, looks like an ID
@@ -150,6 +186,40 @@ describe("resolveDocumentRef", () => {
 		});
 		expect(mockApiRequest).toHaveBeenNthCalledWith(2, "documents.list", {
 			limit: 100,
+			offset: 0,
+		});
+	});
+
+	it("paginates to fetch all documents when workspace has >100", async () => {
+		// Create 150 mock docs to simulate pagination
+		const page1 = Array.from({ length: 100 }, (_, i) => ({
+			id: `doc-${i}`,
+			title: `Doc ${i}`,
+			urlId: `doc-${i}-abc`,
+		}));
+		const page2 = Array.from({ length: 50 }, (_, i) => ({
+			id: `doc-${100 + i}`,
+			title: `Doc ${100 + i}`,
+			urlId: `doc-${100 + i}-abc`,
+		}));
+
+		mockApiRequest
+			.mockResolvedValueOnce({ data: page1 }) // first page (100 items)
+			.mockResolvedValueOnce({ data: page2 }); // second page (50 items)
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		// Search for a doc that's on page 2
+		const result = await resolveDocumentRef("Doc 125");
+
+		expect(result).toEqual(page2[25]);
+		expect(mockApiRequest).toHaveBeenCalledTimes(2);
+		expect(mockApiRequest).toHaveBeenNthCalledWith(1, "documents.list", {
+			limit: 100,
+			offset: 0,
+		});
+		expect(mockApiRequest).toHaveBeenNthCalledWith(2, "documents.list", {
+			limit: 100,
+			offset: 100,
 		});
 	});
 });

--- a/src/lib/refs.test.ts
+++ b/src/lib/refs.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./auth.js", () => ({
+	getApiToken: () => "test-token",
+	getBaseUrl: () => "https://test.outline.com",
+}));
+
+const mockApiRequest = vi.fn();
+vi.mock("./api.js", () => ({
+	apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}));
+
+describe("resolveDocumentRef", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockApiRequest.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("resolves document by exact ID (UUID format)", async () => {
+		const mockDoc = {
+			id: "550e8400-e29b-41d4-a716-446655440000",
+			title: "Test Doc",
+			urlId: "test-doc-abc",
+		};
+		mockApiRequest.mockResolvedValueOnce({ data: mockDoc });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		const result = await resolveDocumentRef(
+			"550e8400-e29b-41d4-a716-446655440000",
+		);
+
+		expect(result).toEqual(mockDoc);
+		expect(mockApiRequest).toHaveBeenCalledWith("documents.info", {
+			id: "550e8400-e29b-41d4-a716-446655440000",
+		});
+	});
+
+	it("resolves document by short alphanumeric ID", async () => {
+		const mockDoc = { id: "abc123", title: "Test Doc", urlId: "test-doc-abc" };
+		mockApiRequest.mockResolvedValueOnce({ data: mockDoc });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		const result = await resolveDocumentRef("abc123");
+
+		expect(result).toEqual(mockDoc);
+		expect(mockApiRequest).toHaveBeenCalledWith("documents.info", {
+			id: "abc123",
+		});
+	});
+
+	it("extracts ID from URL slug and resolves", async () => {
+		const mockDoc = {
+			id: "xyz789",
+			title: "My Document",
+			urlId: "my-doc-xyz789",
+		};
+		mockApiRequest.mockResolvedValueOnce({ data: mockDoc });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		const result = await resolveDocumentRef("my-document-xyz789");
+
+		expect(result).toEqual(mockDoc);
+		expect(mockApiRequest).toHaveBeenCalledWith("documents.info", {
+			id: "xyz789",
+		});
+	});
+
+	it("resolves document by exact name match (case-insensitive)", async () => {
+		const mockDocs = [
+			{ id: "1", title: "Engineering Guide", urlId: "eng-1" },
+			{ id: "2", title: "Product Docs", urlId: "prod-2" },
+		];
+		// "engineering guide" has spaces, doesn't look like an ID
+		mockApiRequest.mockResolvedValueOnce({ data: mockDocs });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		const result = await resolveDocumentRef("engineering guide");
+
+		expect(result).toEqual(mockDocs[0]);
+	});
+
+	it("resolves document by partial name match when unique", async () => {
+		const mockDocs = [
+			{ id: "1", title: "Engineering Guide", urlId: "eng-1" },
+			{ id: "2", title: "Product Docs", urlId: "prod-2" },
+		];
+		// "product" is 7 chars, looks like an ID, so will try ID lookup first
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found")) // ID lookup fails
+			.mockResolvedValueOnce({ data: mockDocs }); // falls back to list
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		const result = await resolveDocumentRef("product");
+
+		expect(result).toEqual(mockDocs[1]);
+	});
+
+	it("throws ambiguous error when multiple partial matches", async () => {
+		const mockDocs = [
+			{ id: "1", title: "Engineering Guide", urlId: "eng-1" },
+			{ id: "2", title: "Engineering Handbook", urlId: "eng-2" },
+		];
+		// "engineering" is 11 chars, looks like an ID
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found"))
+			.mockResolvedValueOnce({ data: mockDocs });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		await expect(resolveDocumentRef("engineering")).rejects.toThrow(
+			/Ambiguous Document reference/,
+		);
+	});
+
+	it("throws not found error when no matches", async () => {
+		const mockDocs = [{ id: "1", title: "Engineering Guide", urlId: "eng-1" }];
+		// "nonexistent" is 11 chars, looks like an ID
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found"))
+			.mockResolvedValueOnce({ data: mockDocs });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+		await expect(resolveDocumentRef("nonexistent")).rejects.toThrow(
+			'Document not found: "nonexistent"',
+		);
+	});
+
+	it("falls back to name search when ID lookup fails", async () => {
+		const mockDocs = [
+			{ id: "1", title: "Engineering Guide", urlId: "eng-1" },
+			{ id: "2", title: "Product Docs", urlId: "prod-2" },
+		];
+		// "abc123" looks like an ID, but fails, then falls back to name search
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found"))
+			.mockResolvedValueOnce({ data: mockDocs });
+
+		const { resolveDocumentRef } = await import("./refs.js");
+
+		// Should fall back to name search and throw "not found"
+		await expect(resolveDocumentRef("abc123")).rejects.toThrow(
+			'Document not found: "abc123"',
+		);
+		expect(mockApiRequest).toHaveBeenCalledTimes(2);
+		expect(mockApiRequest).toHaveBeenNthCalledWith(1, "documents.info", {
+			id: "abc123",
+		});
+		expect(mockApiRequest).toHaveBeenNthCalledWith(2, "documents.list", {
+			limit: 100,
+		});
+	});
+});
+
+describe("resolveCollectionRef", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockApiRequest.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("resolves collection by exact ID", async () => {
+		const mockCol = { id: "col123", name: "Engineering" };
+		mockApiRequest.mockResolvedValueOnce({ data: mockCol });
+
+		const { resolveCollectionRef } = await import("./refs.js");
+		const result = await resolveCollectionRef("col123");
+
+		expect(result).toEqual(mockCol);
+		expect(mockApiRequest).toHaveBeenCalledWith("collections.info", {
+			id: "col123",
+		});
+	});
+
+	it("resolves collection by exact name match", async () => {
+		const mockCols = [
+			{ id: "1", name: "Engineering" },
+			{ id: "2", name: "Product" },
+		];
+		// "Engineering" is 11 chars, looks like an ID
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found"))
+			.mockResolvedValueOnce({ data: mockCols });
+
+		const { resolveCollectionRef } = await import("./refs.js");
+		const result = await resolveCollectionRef("Engineering");
+
+		expect(result).toEqual(mockCols[0]);
+	});
+
+	it("resolves collection by partial name match when unique", async () => {
+		const mockCols = [
+			{ id: "1", name: "Engineering" },
+			{ id: "2", name: "Product" },
+		];
+		// "prod" is 4 chars, doesn't look like an ID (needs 6+)
+		mockApiRequest.mockResolvedValueOnce({ data: mockCols });
+
+		const { resolveCollectionRef } = await import("./refs.js");
+		const result = await resolveCollectionRef("prod");
+
+		expect(result).toEqual(mockCols[1]);
+	});
+
+	it("throws ambiguous error when multiple partial matches", async () => {
+		const mockCols = [
+			{ id: "1", name: "Engineering Frontend" },
+			{ id: "2", name: "Engineering Backend" },
+		];
+		// "engineering" is 11 chars, looks like an ID
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found"))
+			.mockResolvedValueOnce({ data: mockCols });
+
+		const { resolveCollectionRef } = await import("./refs.js");
+		await expect(resolveCollectionRef("engineering")).rejects.toThrow(
+			/Ambiguous Collection reference/,
+		);
+	});
+
+	it("throws not found error when no matches", async () => {
+		const mockCols = [{ id: "1", name: "Engineering" }];
+		// "nonexistent" is 11 chars, looks like an ID
+		mockApiRequest
+			.mockRejectedValueOnce(new Error("Not found"))
+			.mockResolvedValueOnce({ data: mockCols });
+
+		const { resolveCollectionRef } = await import("./refs.js");
+		await expect(resolveCollectionRef("nonexistent")).rejects.toThrow(
+			'Collection not found: "nonexistent"',
+		);
+	});
+});
+
+describe("resolveDocumentId", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockApiRequest.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns just the ID string", async () => {
+		const mockDoc = { id: "doc-id-123", title: "Test", urlId: "test-abc" };
+		mockApiRequest.mockResolvedValueOnce({ data: mockDoc });
+
+		const { resolveDocumentId } = await import("./refs.js");
+		const result = await resolveDocumentId("testabc");
+
+		expect(result).toBe("doc-id-123");
+	});
+});
+
+describe("resolveCollectionId", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		mockApiRequest.mockReset();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns just the ID string", async () => {
+		const mockCol = { id: "col-id-123", name: "Engineering" };
+		mockApiRequest.mockResolvedValueOnce({ data: mockCol });
+
+		const { resolveCollectionId } = await import("./refs.js");
+		const result = await resolveCollectionId("colid123");
+
+		expect(result).toBe("col-id-123");
+	});
+});

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -1,15 +1,22 @@
 import { apiRequest } from "./api.js";
 
-interface Document {
+export interface Document {
 	id: string;
 	title: string;
 	url: string;
 	urlId: string;
+	text?: string;
 }
 
-interface Collection {
+export interface Collection {
 	id: string;
 	name: string;
+	description?: string;
+	color?: string;
+	permission?: string;
+	createdAt?: string;
+	updatedAt?: string;
+	documentCount?: number;
 }
 
 /**
@@ -37,11 +44,11 @@ function looksLikeId(input: string): boolean {
 }
 
 /**
- * Extract document ID from URL or slug
+ * Extract document ID from URL or slug (document-only)
  * Only extracts from slugs (e.g., "my-doc-abc123" -> "abc123")
  * Preserves full UUIDs and raw IDs
  */
-function extractDocumentId(input: string): string {
+function extractDocumentIdFromSlug(input: string): string {
 	// Preserve UUIDs as-is
 	if (isUuid(input)) {
 		return input;
@@ -62,27 +69,44 @@ function extractDocumentId(input: string): string {
 function formatSuggestions<T>(
 	items: T[],
 	getName: (item: T) => string,
-	getId: (item: T) => string,
+	getDisplayId: (item: T) => string,
 	max = 5,
 ): string {
 	const suggestions = items.slice(0, max);
 	return suggestions
-		.map((item) => `  - "${getName(item)}" (${getId(item)})`)
+		.map((item) => `  - "${getName(item)}" (${getDisplayId(item)})`)
 		.join("\n");
+}
+
+interface ResolveRefOptions<T extends { id: string }> {
+	ref: string;
+	fetchById: (id: string) => Promise<T>;
+	fetchAllPaginated: () => Promise<T[]>;
+	getName: (item: T) => string;
+	getDisplayId: (item: T) => string;
+	entityType: string;
+	extractSlugId: boolean;
 }
 
 /**
  * Generic fuzzy reference resolver
  */
 async function resolveRef<T extends { id: string }>(
-	ref: string,
-	fetchById: (id: string) => Promise<T>,
-	fetchAll: () => Promise<T[]>,
-	getName: (item: T) => string,
-	entityType: string,
+	options: ResolveRefOptions<T>,
 ): Promise<T> {
+	const {
+		ref,
+		fetchById,
+		fetchAllPaginated,
+		getName,
+		getDisplayId,
+		entityType,
+		extractSlugId,
+	} = options;
+
 	// Try direct ID lookup first if it looks like an ID
-	const extractedId = extractDocumentId(ref);
+	// Only extract slug ID for documents, not collections
+	const extractedId = extractSlugId ? extractDocumentIdFromSlug(ref) : ref;
 	if (looksLikeId(extractedId)) {
 		try {
 			return await fetchById(extractedId);
@@ -91,15 +115,26 @@ async function resolveRef<T extends { id: string }>(
 		}
 	}
 
-	// Fetch all items and search by name
-	const items = await fetchAll();
+	// Fetch all items with pagination and search by name
+	const items = await fetchAllPaginated();
 	const refLower = ref.toLowerCase();
 
 	// Try exact match first (case-insensitive)
-	const exactMatch = items.find(
+	const exactMatches = items.filter(
 		(item) => getName(item).toLowerCase() === refLower,
 	);
-	if (exactMatch) return exactMatch;
+
+	if (exactMatches.length === 1) {
+		return exactMatches[0];
+	}
+
+	// Multiple exact matches are ambiguous
+	if (exactMatches.length > 1) {
+		const suggestions = formatSuggestions(exactMatches, getName, getDisplayId);
+		throw new Error(
+			`Ambiguous ${entityType} reference "${ref}". Multiple items have this exact name:\n${suggestions}`,
+		);
+	}
 
 	// Try partial match
 	const partialMatches = items.filter((item) =>
@@ -114,7 +149,7 @@ async function resolveRef<T extends { id: string }>(
 		const suggestions = formatSuggestions(
 			partialMatches,
 			getName,
-			(item) => item.id,
+			getDisplayId,
 		);
 		throw new Error(
 			`Ambiguous ${entityType} reference "${ref}". Did you mean:\n${suggestions}`,
@@ -126,24 +161,67 @@ async function resolveRef<T extends { id: string }>(
 }
 
 /**
+ * Fetch all documents with pagination
+ */
+async function fetchAllDocuments(): Promise<Document[]> {
+	const allDocs: Document[] = [];
+	const limit = 100;
+	let offset = 0;
+
+	while (true) {
+		const { data } = await apiRequest<Document[]>("documents.list", {
+			limit,
+			offset,
+		});
+		allDocs.push(...data);
+		if (data.length < limit) {
+			break;
+		}
+		offset += limit;
+	}
+
+	return allDocs;
+}
+
+/**
+ * Fetch all collections with pagination
+ */
+async function fetchAllCollections(): Promise<Collection[]> {
+	const allCollections: Collection[] = [];
+	const limit = 100;
+	let offset = 0;
+
+	while (true) {
+		const { data } = await apiRequest<Collection[]>("collections.list", {
+			limit,
+			offset,
+		});
+		allCollections.push(...data);
+		if (data.length < limit) {
+			break;
+		}
+		offset += limit;
+	}
+
+	return allCollections;
+}
+
+/**
  * Resolve a document reference by ID, URL, or name
  */
 export async function resolveDocumentRef(ref: string): Promise<Document> {
-	return resolveRef<Document>(
+	return resolveRef<Document>({
 		ref,
-		async (id) => {
+		fetchById: async (id) => {
 			const { data } = await apiRequest<Document>("documents.info", { id });
 			return data;
 		},
-		async () => {
-			const { data } = await apiRequest<Document[]>("documents.list", {
-				limit: 100,
-			});
-			return data;
-		},
-		(doc) => doc.title,
-		"Document",
-	);
+		fetchAllPaginated: fetchAllDocuments,
+		getName: (doc) => doc.title,
+		getDisplayId: (doc) => doc.urlId,
+		entityType: "Document",
+		extractSlugId: true,
+	});
 }
 
 /**
@@ -158,21 +236,18 @@ export async function resolveDocumentId(ref: string): Promise<string> {
  * Resolve a collection reference by ID or name
  */
 export async function resolveCollectionRef(ref: string): Promise<Collection> {
-	return resolveRef<Collection>(
+	return resolveRef<Collection>({
 		ref,
-		async (id) => {
+		fetchById: async (id) => {
 			const { data } = await apiRequest<Collection>("collections.info", { id });
 			return data;
 		},
-		async () => {
-			const { data } = await apiRequest<Collection[]>("collections.list", {
-				limit: 100,
-			});
-			return data;
-		},
-		(col) => col.name,
-		"Collection",
-	);
+		fetchAllPaginated: fetchAllCollections,
+		getName: (col) => col.name,
+		getDisplayId: (col) => col.id,
+		entityType: "Collection",
+		extractSlugId: false,
+	});
 }
 
 /**

--- a/src/lib/refs.ts
+++ b/src/lib/refs.ts
@@ -1,0 +1,184 @@
+import { apiRequest } from "./api.js";
+
+interface Document {
+	id: string;
+	title: string;
+	url: string;
+	urlId: string;
+}
+
+interface Collection {
+	id: string;
+	name: string;
+}
+
+/**
+ * Check if the input looks like a UUID
+ */
+function isUuid(input: string): boolean {
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+		input,
+	);
+}
+
+/**
+ * Check if the input looks like an Outline ID (UUID or URL ID format)
+ */
+function looksLikeId(input: string): boolean {
+	// UUID format
+	if (isUuid(input)) {
+		return true;
+	}
+	// Short alphanumeric ID (like urlId) - must be 6+ chars and no spaces
+	if (/^[a-zA-Z0-9]{6,}$/.test(input) && !/\s/.test(input)) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Extract document ID from URL or slug
+ * Only extracts from slugs (e.g., "my-doc-abc123" -> "abc123")
+ * Preserves full UUIDs and raw IDs
+ */
+function extractDocumentId(input: string): string {
+	// Preserve UUIDs as-is
+	if (isUuid(input)) {
+		return input;
+	}
+	// If it looks like a URL, extract the slug suffix
+	const parts = input.replace(/\/$/, "").split("/");
+	const last = parts[parts.length - 1];
+	// Outline URL IDs are the part after the last hyphen in the slug
+	// Only extract if it's a slug with hyphen, not just a raw ID
+	const match = last.match(/-([a-zA-Z0-9]+)$/);
+	if (match) return match[1];
+	return input;
+}
+
+/**
+ * Format suggestions for error messages
+ */
+function formatSuggestions<T>(
+	items: T[],
+	getName: (item: T) => string,
+	getId: (item: T) => string,
+	max = 5,
+): string {
+	const suggestions = items.slice(0, max);
+	return suggestions
+		.map((item) => `  - "${getName(item)}" (${getId(item)})`)
+		.join("\n");
+}
+
+/**
+ * Generic fuzzy reference resolver
+ */
+async function resolveRef<T extends { id: string }>(
+	ref: string,
+	fetchById: (id: string) => Promise<T>,
+	fetchAll: () => Promise<T[]>,
+	getName: (item: T) => string,
+	entityType: string,
+): Promise<T> {
+	// Try direct ID lookup first if it looks like an ID
+	const extractedId = extractDocumentId(ref);
+	if (looksLikeId(extractedId)) {
+		try {
+			return await fetchById(extractedId);
+		} catch {
+			// If direct ID lookup fails, fall through to name matching
+		}
+	}
+
+	// Fetch all items and search by name
+	const items = await fetchAll();
+	const refLower = ref.toLowerCase();
+
+	// Try exact match first (case-insensitive)
+	const exactMatch = items.find(
+		(item) => getName(item).toLowerCase() === refLower,
+	);
+	if (exactMatch) return exactMatch;
+
+	// Try partial match
+	const partialMatches = items.filter((item) =>
+		getName(item).toLowerCase().includes(refLower),
+	);
+
+	if (partialMatches.length === 1) {
+		return partialMatches[0];
+	}
+
+	if (partialMatches.length > 1) {
+		const suggestions = formatSuggestions(
+			partialMatches,
+			getName,
+			(item) => item.id,
+		);
+		throw new Error(
+			`Ambiguous ${entityType} reference "${ref}". Did you mean:\n${suggestions}`,
+		);
+	}
+
+	// No matches found
+	throw new Error(`${entityType} not found: "${ref}"`);
+}
+
+/**
+ * Resolve a document reference by ID, URL, or name
+ */
+export async function resolveDocumentRef(ref: string): Promise<Document> {
+	return resolveRef<Document>(
+		ref,
+		async (id) => {
+			const { data } = await apiRequest<Document>("documents.info", { id });
+			return data;
+		},
+		async () => {
+			const { data } = await apiRequest<Document[]>("documents.list", {
+				limit: 100,
+			});
+			return data;
+		},
+		(doc) => doc.title,
+		"Document",
+	);
+}
+
+/**
+ * Resolve a document reference and return just the ID
+ */
+export async function resolveDocumentId(ref: string): Promise<string> {
+	const doc = await resolveDocumentRef(ref);
+	return doc.id;
+}
+
+/**
+ * Resolve a collection reference by ID or name
+ */
+export async function resolveCollectionRef(ref: string): Promise<Collection> {
+	return resolveRef<Collection>(
+		ref,
+		async (id) => {
+			const { data } = await apiRequest<Collection>("collections.info", { id });
+			return data;
+		},
+		async () => {
+			const { data } = await apiRequest<Collection[]>("collections.list", {
+				limit: 100,
+			});
+			return data;
+		},
+		(col) => col.name,
+		"Collection",
+	);
+}
+
+/**
+ * Resolve a collection reference and return just the ID
+ */
+export async function resolveCollectionId(ref: string): Promise<string> {
+	const col = await resolveCollectionRef(ref);
+	return col.id;
+}


### PR DESCRIPTION
## Summary

- Add `src/lib/refs.ts` module with functions to resolve document and collection references by:
  - Exact ID (UUID or short alphanumeric format)
  - URL slug extraction (e.g., "my-doc-abc123" -> "abc123")
  - Exact name match (case-insensitive)
  - Partial name match (if unique match found)
  - Helpful error messages with suggestions for ambiguous matches
- Update document commands to use fuzzy resolvers
- Update collection commands to use fuzzy resolvers
- Add comprehensive tests in `src/lib/refs.test.ts`

Closes #10

## Test plan

- [x] Run `npm run type-check` - passes
- [x] Run `npm test` - all 50 tests pass
- [x] Verify document commands work with name references
- [x] Verify collection commands work with name references

🤖 Generated with [Claude Code](https://claude.com/claude-code)