### PR TITLE
feat: improve oauth login inputs and callback UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ol auth logout    # clear saved credentials
 **Setup:**
 
 1. Create a public OAuth app in Outline (Settings → Applications)
-2. Set the redirect URI to `http://localhost` (any port is fine)
+2. Set the redirect URI to `http://localhost:54969/callback`
 3. Run `ol auth login` and enter your OAuth client ID when prompted
    (or pass it directly with `--client-id <your-client-id>`)
 4. If needed, pass `--base-url <your-outline-url>` or set `OUTLINE_URL`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ npm link
 
 ```sh
 ol auth login     # opens browser for OAuth authorization
+ol auth login --base-url <your-outline-url> # skip base URL prompt for this login
+ol auth login --client-id <your-client-id>  # skip prompt for this login
 ol auth status    # show current auth state
 ol auth logout    # clear saved credentials
 ```
@@ -35,8 +37,12 @@ ol auth logout    # clear saved credentials
 1. Create a public OAuth app in Outline (Settings → Applications)
 2. Set the redirect URI to `http://localhost` (any port is fine)
 3. Run `ol auth login` and enter your OAuth client ID when prompted
+   (or pass it directly with `--client-id <your-client-id>`)
+4. If needed, pass `--base-url <your-outline-url>` or set `OUTLINE_URL`
+   (for self-hosted instances or non-default URLs)
 
-The client ID is saved for future logins. You can also set `OUTLINE_OAUTH_CLIENT_ID` env var.
+The client ID is saved for future logins. You can also set `OUTLINE_OAUTH_CLIENT_ID`
+for your local environment.
 
 ### Manual token login
 
@@ -54,7 +60,7 @@ Token resolution: `OUTLINE_API_TOKEN` env var → `~/.config/outline-cli/config.
 
 Base URL resolution: `OUTLINE_URL` env var → config file → `https://app.getoutline.com`.
 
-Self-hosted instances: provide your instance URL during `ol auth login` or set `OUTLINE_URL`.
+Self-hosted instances: pass `--base-url` or set `OUTLINE_URL` (you can still provide it interactively).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm link
 ol auth login     # opens browser for OAuth authorization
 ol auth login --base-url <your-outline-url> # skip base URL prompt for this login
 ol auth login --client-id <your-client-id>  # skip prompt for this login
+ol auth login --callback-port 54969         # override local callback port
 ol auth status    # show current auth state
 ol auth logout    # clear saved credentials
 ```
@@ -40,6 +41,8 @@ ol auth logout    # clear saved credentials
    (or pass it directly with `--client-id <your-client-id>`)
 4. If needed, pass `--base-url <your-outline-url>` or set `OUTLINE_URL`
    (for self-hosted instances or non-default URLs)
+5. If needed, pass `--callback-port <port>` or set `OUTLINE_OAUTH_CALLBACK_PORT`
+   and register `http://localhost:<port>/callback` in your OAuth app
 
 The client ID is saved for future logins. You can also set `OUTLINE_OAUTH_CLIENT_ID`
 for your local environment.
@@ -59,6 +62,9 @@ Generate a token in Outline under Settings → API Tokens.
 Token resolution: `OUTLINE_API_TOKEN` env var → `~/.config/outline-cli/config.json`.
 
 Base URL resolution: `OUTLINE_URL` env var → config file → `https://app.getoutline.com`.
+
+Callback port resolution for OAuth login:
+`--callback-port` → `OUTLINE_OAUTH_CALLBACK_PORT` → `54969`.
 
 Self-hosted instances: pass `--base-url` or set `OUTLINE_URL` (you can still provide it interactively).
 

--- a/src/__tests__/oauth-server.test.ts
+++ b/src/__tests__/oauth-server.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { startOAuthCallbackServer } from "../lib/oauth-server.js";
+
+describe("oauth callback server", () => {
+	it("returns success page and resolves authorization code", async () => {
+		const callbackServer = await startOAuthCallbackServer({
+			state: "expected-state",
+			timeoutMs: 10_000,
+		});
+
+		const response = await fetch(
+			`${callbackServer.redirectUri}?code=test-code&state=expected-state`,
+		);
+		const html = await response.text();
+
+		expect(response.status).toBe(200);
+		expect(html).toContain("Login complete");
+		await expect(callbackServer.waitForCode).resolves.toBe("test-code");
+	});
+
+	it("returns error page and rejects on state mismatch", async () => {
+		const callbackServer = await startOAuthCallbackServer({
+			state: "expected-state",
+			timeoutMs: 10_000,
+		});
+		const rejection = callbackServer.waitForCode.then(
+			() => new Error("Expected OAuth state mismatch."),
+			(error) => error as Error,
+		);
+
+		const response = await fetch(
+			`${callbackServer.redirectUri}?code=test-code&state=wrong-state`,
+		);
+		const html = await response.text();
+
+		expect(response.status).toBe(400);
+		expect(html).toContain("Authentication failed");
+		const error = await rejection;
+		expect(error.message).toBe("OAuth state mismatch.");
+	});
+
+	it("returns error page and rejects when OAuth provider sends an error", async () => {
+		const callbackServer = await startOAuthCallbackServer({
+			state: "expected-state",
+			timeoutMs: 10_000,
+		});
+		const rejection = callbackServer.waitForCode.then(
+			() => new Error("Expected OAuth provider error."),
+			(error) => error as Error,
+		);
+
+		const response = await fetch(
+			`${callbackServer.redirectUri}?error=access_denied&error_description=User%20denied`,
+		);
+		const html = await response.text();
+
+		expect(response.status).toBe(400);
+		expect(html).toContain("Authentication failed");
+		const error = await rejection;
+		expect(error.message).toBe("OAuth authorization denied: User denied");
+	});
+});

--- a/src/__tests__/oauth-server.test.ts
+++ b/src/__tests__/oauth-server.test.ts
@@ -6,6 +6,7 @@ describe("oauth callback server", () => {
 		const callbackServer = await startOAuthCallbackServer({
 			state: "expected-state",
 			timeoutMs: 10_000,
+			port: 0,
 		});
 
 		const response = await fetch(
@@ -22,6 +23,7 @@ describe("oauth callback server", () => {
 		const callbackServer = await startOAuthCallbackServer({
 			state: "expected-state",
 			timeoutMs: 10_000,
+			port: 0,
 		});
 		const rejection = callbackServer.waitForCode.then(
 			() => new Error("Expected OAuth state mismatch."),
@@ -43,6 +45,7 @@ describe("oauth callback server", () => {
 		const callbackServer = await startOAuthCallbackServer({
 			state: "expected-state",
 			timeoutMs: 10_000,
+			port: 0,
 		});
 		const rejection = callbackServer.waitForCode.then(
 			() => new Error("Expected OAuth provider error."),

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -11,7 +11,10 @@ import {
 	saveConfig,
 } from "../lib/auth.js";
 import { buildAuthorizationUrl, exchangeCodeForToken } from "../lib/oauth.js";
-import { startOAuthCallbackServer } from "../lib/oauth-server.js";
+import {
+	DEFAULT_OAUTH_CALLBACK_PORT,
+	startOAuthCallbackServer,
+} from "../lib/oauth-server.js";
 import { formatError } from "../lib/output.js";
 import {
 	generateCodeChallenge,
@@ -117,7 +120,32 @@ export function registerAuthCommand(program: Command): void {
 				const codeChallenge = generateCodeChallenge(codeVerifier);
 				const state = generateState();
 
-				const callbackServer = await startOAuthCallbackServer({ state });
+				let callbackServer: Awaited<
+					ReturnType<typeof startOAuthCallbackServer>
+				>;
+				try {
+					callbackServer = await startOAuthCallbackServer({ state });
+				} catch (err) {
+					const error = err as NodeJS.ErrnoException;
+					const hints = [
+						`Ensure http://localhost:${DEFAULT_OAUTH_CALLBACK_PORT}/callback is reachable from your browser`,
+						"Re-run with 'ol auth login --token <token>' for manual auth",
+					];
+					if (error.code === "EADDRINUSE") {
+						hints.unshift(
+							`Port ${DEFAULT_OAUTH_CALLBACK_PORT} is already in use. Close the other process using it.`,
+						);
+					}
+
+					console.error(
+						formatError(
+							"OAUTH_CALLBACK_SERVER_FAILED",
+							`Could not start local OAuth callback server: ${error.message}`,
+							hints,
+						),
+					);
+					process.exit(1);
+				}
 				const authorizationUrl = buildAuthorizationUrl({
 					baseUrl: url,
 					clientId,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -45,16 +45,114 @@ export function registerAuthCommand(program: Command): void {
 		.command("login")
 		.description("Authenticate with an Outline instance")
 		.option("--token <token>", "Authenticate using a personal API token")
-		.action(async (options: { token?: string }) => {
-			const configuredBaseUrl = getBaseUrl();
-			const baseUrlInput = await prompt(
-				`Base URL (default: ${configuredBaseUrl}): `,
-			);
-			const url = (baseUrlInput.trim() || configuredBaseUrl).replace(/\/$/, "");
+		.option(
+			"--base-url <url>",
+			"Outline base URL to use for this login (saved for future logins)",
+		)
+		.option(
+			"--client-id <clientId>",
+			"OAuth client ID to use for this login (saved for future logins)",
+		)
+		.action(
+			async (options: {
+				token?: string;
+				clientId?: string;
+				baseUrl?: string;
+			}) => {
+				const configuredBaseUrl = getBaseUrl();
+				const optionBaseUrl = options.baseUrl?.trim();
+				const envBaseUrl = process.env.OUTLINE_URL?.trim();
+				let url = optionBaseUrl || envBaseUrl;
+				if (!url) {
+					const baseUrlInput = await prompt(
+						`Base URL (default: ${configuredBaseUrl}): `,
+					);
+					url = baseUrlInput.trim() || configuredBaseUrl;
+				}
+				url = url.replace(/\/$/, "");
+				const optionClientId = options.clientId?.trim();
 
-			if (options.token) {
-				saveConfig(options.token.trim(), url);
+				if (options.token) {
+					saveConfig(options.token.trim(), url, optionClientId);
+					try {
+						const { data } = await apiRequest<AuthInfoResponse>("auth.info");
+						console.log(
+							chalk.green(
+								`Authenticated to ${data.team.name} as ${data.user.name}`,
+							),
+						);
+					} catch (err) {
+						console.log(
+							chalk.yellow("Token saved, but could not verify:"),
+							(err as Error).message,
+						);
+					}
+					return;
+				}
+
+				const existingClientId = getOAuthClientId();
+				let clientId = optionClientId || existingClientId;
+
+				if (!clientId) {
+					const clientIdPrompt = existingClientId
+						? `OAuth Client ID (default: ${existingClientId}): `
+						: "OAuth Client ID: ";
+					const clientIdInput = await prompt(clientIdPrompt);
+					clientId = clientIdInput.trim() || existingClientId;
+				}
+
+				if (!clientId) {
+					console.error(
+						formatError(
+							"OAUTH_CLIENT_ID_REQUIRED",
+							"OAuth client ID is required.",
+							[
+								"Create a public OAuth app in Outline settings",
+								"Use --client-id <id> for this login",
+								"Set OUTLINE_OAUTH_CLIENT_ID or enter it here",
+							],
+						),
+					);
+					process.exit(1);
+				}
+
+				const codeVerifier = generateCodeVerifier();
+				const codeChallenge = generateCodeChallenge(codeVerifier);
+				const state = generateState();
+
+				const callbackServer = await startOAuthCallbackServer({ state });
+				const authorizationUrl = buildAuthorizationUrl({
+					baseUrl: url,
+					clientId,
+					redirectUri: callbackServer.redirectUri,
+					codeChallenge,
+					state,
+				});
+
 				try {
+					await open(authorizationUrl);
+				} catch (err) {
+					console.log(
+						chalk.yellow("Could not open browser automatically."),
+						chalk.dim(authorizationUrl),
+					);
+					console.log(chalk.dim((err as Error).message));
+				}
+
+				console.log(chalk.dim("Waiting for OAuth authorization..."));
+
+				try {
+					const code = await callbackServer.waitForCode;
+					const token = await exchangeCodeForToken({
+						baseUrl: url,
+						clientId,
+						redirectUri: callbackServer.redirectUri,
+						codeVerifier,
+						code,
+					});
+
+					saveConfig(token, url, clientId);
+
 					const { data } = await apiRequest<AuthInfoResponse>("auth.info");
 					console.log(
 						chalk.green(
@@ -62,93 +160,22 @@ export function registerAuthCommand(program: Command): void {
 						),
 					);
 				} catch (err) {
-					console.log(
-						chalk.yellow("Token saved, but could not verify:"),
-						(err as Error).message,
+					callbackServer.close();
+					console.error(
+						formatError(
+							"OAUTH_LOGIN_FAILED",
+							`OAuth login failed: ${(err as Error).message}`,
+							[
+								"Confirm the OAuth app redirect URI matches the CLI callback",
+								"Verify --base-url or OUTLINE_URL points to your Outline instance",
+								"Re-run with 'ol auth login --token' for manual auth",
+							],
+						),
 					);
+					process.exit(1);
 				}
-				return;
-			}
-
-			const existingClientId = getOAuthClientId();
-			const clientIdPrompt = existingClientId
-				? `OAuth Client ID (default: ${existingClientId}): `
-				: "OAuth Client ID: ";
-			const clientIdInput = await prompt(clientIdPrompt);
-			const clientId = clientIdInput.trim() || existingClientId;
-
-			if (!clientId) {
-				console.error(
-					formatError(
-						"OAUTH_CLIENT_ID_REQUIRED",
-						"OAuth client ID is required.",
-						[
-							"Create a public OAuth app in Outline settings",
-							"Set OUTLINE_OAUTH_CLIENT_ID or enter it here",
-						],
-					),
-				);
-				process.exit(1);
-			}
-
-			const codeVerifier = generateCodeVerifier();
-			const codeChallenge = generateCodeChallenge(codeVerifier);
-			const state = generateState();
-
-			const callbackServer = await startOAuthCallbackServer({ state });
-			const authorizationUrl = buildAuthorizationUrl({
-				baseUrl: url,
-				clientId,
-				redirectUri: callbackServer.redirectUri,
-				codeChallenge,
-				state,
-			});
-
-			try {
-				await open(authorizationUrl);
-			} catch (err) {
-				console.log(
-					chalk.yellow("Could not open browser automatically."),
-					chalk.dim(authorizationUrl),
-				);
-				console.log(chalk.dim((err as Error).message));
-			}
-
-			console.log(chalk.dim("Waiting for OAuth authorization..."));
-
-			try {
-				const code = await callbackServer.waitForCode;
-				const token = await exchangeCodeForToken({
-					baseUrl: url,
-					clientId,
-					redirectUri: callbackServer.redirectUri,
-					codeVerifier,
-					code,
-				});
-
-				saveConfig(token, url, clientId);
-
-				const { data } = await apiRequest<AuthInfoResponse>("auth.info");
-				console.log(
-					chalk.green(
-						`Authenticated to ${data.team.name} as ${data.user.name}`,
-					),
-				);
-			} catch (err) {
-				callbackServer.close();
-				console.error(
-					formatError(
-						"OAUTH_LOGIN_FAILED",
-						`OAuth login failed: ${(err as Error).message}`,
-						[
-							"Confirm the OAuth app redirect URI matches the CLI callback",
-							"Re-run with 'ol auth login --token' for manual auth",
-						],
-					),
-				);
-				process.exit(1);
-			}
-		});
+			},
+		);
 
 	auth
 		.command("status")

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -94,11 +94,8 @@ export function registerAuthCommand(program: Command): void {
 				let clientId = optionClientId || existingClientId;
 
 				if (!clientId) {
-					const clientIdPrompt = existingClientId
-						? `OAuth Client ID (default: ${existingClientId}): `
-						: "OAuth Client ID: ";
-					const clientIdInput = await prompt(clientIdPrompt);
-					clientId = clientIdInput.trim() || existingClientId;
+					const clientIdInput = await prompt("OAuth Client ID: ");
+					clientId = clientIdInput.trim();
 				}
 
 				if (!clientId) {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -41,6 +41,14 @@ async function prompt(question: string): Promise<string> {
 	}
 }
 
+function parseCallbackPort(rawPort: string): number | null {
+	const parsed = Number(rawPort);
+	if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65_535) {
+		return null;
+	}
+	return parsed;
+}
+
 export function registerAuthCommand(program: Command): void {
 	const auth = program.command("auth").description("Manage authentication");
 
@@ -56,11 +64,16 @@ export function registerAuthCommand(program: Command): void {
 			"--client-id <clientId>",
 			"OAuth client ID to use for this login (saved for future logins)",
 		)
+		.option(
+			"--callback-port <port>",
+			`Local OAuth callback port (default: ${DEFAULT_OAUTH_CALLBACK_PORT})`,
+		)
 		.action(
 			async (options: {
 				token?: string;
 				clientId?: string;
 				baseUrl?: string;
+				callbackPort?: string;
 			}) => {
 				const configuredBaseUrl = getBaseUrl();
 				const optionBaseUrl = options.baseUrl?.trim();
@@ -74,6 +87,28 @@ export function registerAuthCommand(program: Command): void {
 				}
 				url = url.replace(/\/$/, "");
 				const optionClientId = options.clientId?.trim();
+				const optionCallbackPort = options.callbackPort?.trim();
+				const envCallbackPort = process.env.OUTLINE_OAUTH_CALLBACK_PORT?.trim();
+				const rawCallbackPort = optionCallbackPort || envCallbackPort;
+				let callbackPort = DEFAULT_OAUTH_CALLBACK_PORT;
+
+				if (rawCallbackPort) {
+					const parsedPort = parseCallbackPort(rawCallbackPort);
+					if (!parsedPort) {
+						console.error(
+							formatError(
+								"OAUTH_CALLBACK_PORT_INVALID",
+								`Invalid callback port: ${rawCallbackPort}`,
+								[
+									"Use an integer between 1 and 65535",
+									"Set via --callback-port or OUTLINE_OAUTH_CALLBACK_PORT",
+								],
+							),
+						);
+						process.exit(1);
+					}
+					callbackPort = parsedPort;
+				}
 
 				if (options.token) {
 					saveConfig(options.token.trim(), url, optionClientId);
@@ -124,16 +159,19 @@ export function registerAuthCommand(program: Command): void {
 					ReturnType<typeof startOAuthCallbackServer>
 				>;
 				try {
-					callbackServer = await startOAuthCallbackServer({ state });
+					callbackServer = await startOAuthCallbackServer({
+						state,
+						port: callbackPort,
+					});
 				} catch (err) {
 					const error = err as NodeJS.ErrnoException;
 					const hints = [
-						`Ensure http://localhost:${DEFAULT_OAUTH_CALLBACK_PORT}/callback is reachable from your browser`,
+						`Ensure http://localhost:${callbackPort}/callback is reachable from your browser`,
 						"Re-run with 'ol auth login --token <token>' for manual auth",
 					];
 					if (error.code === "EADDRINUSE") {
 						hints.unshift(
-							`Port ${DEFAULT_OAUTH_CALLBACK_PORT} is already in use. Close the other process using it.`,
+							`Port ${callbackPort} is already in use. Close the other process using it.`,
 						);
 					}
 

--- a/src/lib/oauth-server.ts
+++ b/src/lib/oauth-server.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 interface OAuthServerOptions {
 	state: string;
 	timeoutMs?: number;
+	port?: number;
 }
 
 export interface OAuthCallbackServer {
@@ -12,6 +13,8 @@ export interface OAuthCallbackServer {
 	waitForCode: Promise<string>;
 	close: () => void;
 }
+
+export const DEFAULT_OAUTH_CALLBACK_PORT = 54969;
 
 function escapeHtml(text: string): string {
 	return text
@@ -128,7 +131,11 @@ function renderErrorPage(message: string): string {
 export async function startOAuthCallbackServer(
 	options: OAuthServerOptions,
 ): Promise<OAuthCallbackServer> {
-	const { state, timeoutMs = 3 * 60 * 1000 } = options;
+	const {
+		state,
+		timeoutMs = 3 * 60 * 1000,
+		port = DEFAULT_OAUTH_CALLBACK_PORT,
+	} = options;
 	let origin = "http://localhost";
 	let resolved = false;
 	let resolveCode: (code: string) => void;
@@ -202,12 +209,23 @@ export async function startOAuthCallbackServer(
 		rejectCode(err as Error);
 	});
 
-	await new Promise<void>((resolve) => {
-		server.listen(0, "127.0.0.1", resolve);
+	await new Promise<void>((resolve, reject) => {
+		const onListening = () => {
+			server.off("error", onError);
+			resolve();
+		};
+		const onError = (err: Error) => {
+			server.off("listening", onListening);
+			reject(err);
+		};
+
+		server.once("listening", onListening);
+		server.once("error", onError);
+		server.listen(port, "127.0.0.1");
 	});
 
-	const { port } = server.address() as AddressInfo;
-	origin = `http://localhost:${port}`;
+	const { port: listeningPort } = server.address() as AddressInfo;
+	origin = `http://localhost:${listeningPort}`;
 	const redirectUri = `${origin}/callback`;
 
 	const timeout = setTimeout(() => {
@@ -233,5 +251,5 @@ export async function startOAuthCallbackServer(
 		},
 	);
 
-	return { port, redirectUri, waitForCode, close };
+	return { port: listeningPort, redirectUri, waitForCode, close };
 }

--- a/src/lib/oauth-server.ts
+++ b/src/lib/oauth-server.ts
@@ -13,6 +13,118 @@ export interface OAuthCallbackServer {
 	close: () => void;
 }
 
+function escapeHtml(text: string): string {
+	return text
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+function renderPage(title: string, subtitle: string, body: string): string {
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(title)} - Outline CLI</title>
+  <style>
+    :root {
+      --bg: #f5f7fb;
+      --surface: #ffffff;
+      --border: #e6e9f0;
+      --text: #1e2430;
+      --muted: #586178;
+      --ok: #15803d;
+      --ok-soft: #dcfce7;
+      --err: #b91c1c;
+      --err-soft: #fee2e2;
+      --radius: 14px;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      background: radial-gradient(1200px 500px at 50% -10%, #dbeafe 0%, var(--bg) 60%);
+      color: var(--text);
+      line-height: 1.5;
+      padding: 20px;
+    }
+    .card {
+      width: min(560px, 100%);
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 24px;
+      box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: 24px;
+      letter-spacing: -0.01em;
+    }
+    .subtitle {
+      margin: 0 0 16px;
+      color: var(--muted);
+      font-size: 15px;
+    }
+    .message {
+      border-radius: 12px;
+      padding: 14px 16px;
+      font-size: 14px;
+    }
+    .success {
+      background: var(--ok-soft);
+      color: #14532d;
+    }
+    .error {
+      background: var(--err-soft);
+      color: #7f1d1d;
+    }
+    .hint {
+      margin-top: 14px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    code {
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      background: #eef2ff;
+      border-radius: 6px;
+      padding: 2px 6px;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>${escapeHtml(title)}</h1>
+    <p class="subtitle">${escapeHtml(subtitle)}</p>
+    ${body}
+    <p class="hint">Return to your terminal and continue with <code>ol</code> commands.</p>
+  </main>
+</body>
+</html>`;
+}
+
+function renderSuccessPage(): string {
+	return renderPage(
+		"Login complete",
+		"Outline CLI is now authenticated.",
+		'<div class="message success">You can close this tab now.</div>',
+	);
+}
+
+function renderErrorPage(message: string): string {
+	return renderPage(
+		"Authentication failed",
+		"Outline CLI could not finish OAuth login.",
+		`<div class="message error">${escapeHtml(message)}</div>`,
+	);
+}
+
 export async function startOAuthCallbackServer(
 	options: OAuthServerOptions,
 ): Promise<OAuthCallbackServer> {
@@ -29,21 +141,21 @@ export async function startOAuthCallbackServer(
 
 	const server = http.createServer((req, res) => {
 		if (resolved) {
-			res.writeHead(409);
-			res.end("Authorization already received.");
+			res.writeHead(409, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(renderErrorPage("Authorization was already received."));
 			return;
 		}
 
 		if (req.method !== "GET" || !req.url) {
-			res.writeHead(405);
-			res.end("Method not allowed.");
+			res.writeHead(405, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(renderErrorPage("Invalid callback request method."));
 			return;
 		}
 
 		const url = new URL(req.url, origin);
 		if (url.pathname !== "/callback") {
-			res.writeHead(404);
-			res.end("Not found.");
+			res.writeHead(404, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(renderErrorPage("Unknown callback path."));
 			return;
 		}
 
@@ -52,8 +164,8 @@ export async function startOAuthCallbackServer(
 		if (error) {
 			const errorDescription =
 				url.searchParams.get("error_description") || error;
-			res.writeHead(400);
-			res.end(`Authorization failed: ${errorDescription}`);
+			res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(renderErrorPage(`Authorization failed: ${errorDescription}`));
 			rejectCode(new Error(`OAuth authorization denied: ${errorDescription}`));
 			resolved = true;
 			return;
@@ -63,25 +175,23 @@ export async function startOAuthCallbackServer(
 		const returnedState = url.searchParams.get("state");
 
 		if (!code || !returnedState) {
-			res.writeHead(400);
-			res.end("Missing OAuth parameters.");
+			res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(renderErrorPage("Missing OAuth code or state parameter."));
 			rejectCode(new Error("Missing OAuth authorization code."));
 			resolved = true;
 			return;
 		}
 
 		if (returnedState !== state) {
-			res.writeHead(400);
-			res.end("Invalid OAuth state.");
+			res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+			res.end(renderErrorPage("Invalid OAuth state parameter."));
 			rejectCode(new Error("OAuth state mismatch."));
 			resolved = true;
 			return;
 		}
 
-		res.writeHead(200, { "Content-Type": "text/html" });
-		res.end(
-			"<html><body><h1>Login complete</h1><p>You can close this window.</p></body></html>",
-		);
+		res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+		res.end(renderSuccessPage());
 		resolved = true;
 		resolveCode(code);
 	});
@@ -112,10 +222,16 @@ export async function startOAuthCallbackServer(
 		server.close();
 	};
 
-	waitForCode.finally(() => {
-		clearTimeout(timeout);
-		server.close();
-	});
+	waitForCode.then(
+		() => {
+			clearTimeout(timeout);
+			server.close();
+		},
+		() => {
+			clearTimeout(timeout);
+			server.close();
+		},
+	);
 
 	return { port, redirectUri, waitForCode, close };
 }


### PR DESCRIPTION
This updates `ol auth login` to accept `--client-id` and `--base-url` flags while following a bring-your-own OAuth credentials approach, with no hardcoded client ID in the repo.

The login flow now resolves base URL from `--base-url`, then `OUTLINE_URL`, and prompts only when neither is provided. The localhost OAuth callback server now returns styled UTF-8 HTML success/error pages with escaped messages, and the promise cleanup path was adjusted to avoid unhandled rejection noise.

README auth docs were updated for the new flags and OAuth callback behavior is covered by a new test file for success, state mismatch, and provider error cases.

## Demo

<img width="459" height="560" alt="Image" src="https://github.com/user-attachments/assets/2e081155-93d5-4575-919d-01fab1201edd" />

<img width="703" height="318" alt="CleanShot 2026-03-03 at 21 15 43" src="https://github.com/user-attachments/assets/a868af14-2d50-4a20-ad52-61d3a239a90f" />
