### PR TITLE
fix: honor proxy env vars by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ CLI for the [Outline](https://www.getoutline.com) wiki/knowledge base API.
 
 ## Installation
 
+Requires Node 20.18.1+.
+
 > ```bash
 > npm install -g @doist/outline-cli
 > ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"marked": "15.0.12",
 				"marked-terminal": "7.3.0",
 				"open": "10.2.0",
+				"undici": "7.22.0",
 				"yocto-spinner": "1.0.0"
 			},
 			"bin": {
@@ -121,9 +122,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+			"integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
 			"cpu": [
 				"ppc64"
 			],
@@ -138,9 +139,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+			"integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
 			"cpu": [
 				"arm"
 			],
@@ -155,9 +156,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+			"integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
 			"cpu": [
 				"arm64"
 			],
@@ -172,9 +173,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+			"integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
 			"cpu": [
 				"x64"
 			],
@@ -189,9 +190,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+			"integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -206,9 +207,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+			"integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
 			"cpu": [
 				"x64"
 			],
@@ -223,9 +224,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
 			"cpu": [
 				"arm64"
 			],
@@ -240,9 +241,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+			"integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -257,9 +258,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+			"integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
 			"cpu": [
 				"arm"
 			],
@@ -274,9 +275,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+			"integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
 			"cpu": [
 				"arm64"
 			],
@@ -291,9 +292,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+			"integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
 			"cpu": [
 				"ia32"
 			],
@@ -308,9 +309,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+			"integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
 			"cpu": [
 				"loong64"
 			],
@@ -325,9 +326,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+			"integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -342,9 +343,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+			"integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -359,9 +360,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+			"integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -376,9 +377,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+			"integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
 			"cpu": [
 				"s390x"
 			],
@@ -393,9 +394,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+			"integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
 			"cpu": [
 				"x64"
 			],
@@ -410,9 +411,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -427,9 +428,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
 			"cpu": [
 				"x64"
 			],
@@ -444,9 +445,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
 			"cpu": [
 				"arm64"
 			],
@@ -461,9 +462,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
 			"cpu": [
 				"x64"
 			],
@@ -478,9 +479,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+			"integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
 			"cpu": [
 				"arm64"
 			],
@@ -495,9 +496,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+			"integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
 			"cpu": [
 				"x64"
 			],
@@ -512,9 +513,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+			"integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -529,9 +530,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+			"integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
 			"cpu": [
 				"ia32"
 			],
@@ -546,9 +547,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+			"integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
 			"cpu": [
 				"x64"
 			],
@@ -1418,9 +1419,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.56.0.tgz",
-			"integrity": "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+			"integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
 			"cpu": [
 				"arm"
 			],
@@ -1432,9 +1433,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.56.0.tgz",
-			"integrity": "sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+			"integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1446,9 +1447,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.56.0.tgz",
-			"integrity": "sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+			"integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1460,9 +1461,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.56.0.tgz",
-			"integrity": "sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+			"integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
 			"cpu": [
 				"x64"
 			],
@@ -1474,9 +1475,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.56.0.tgz",
-			"integrity": "sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+			"integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1488,9 +1489,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.56.0.tgz",
-			"integrity": "sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+			"integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
 			"cpu": [
 				"x64"
 			],
@@ -1502,9 +1503,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.56.0.tgz",
-			"integrity": "sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+			"integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
 			"cpu": [
 				"arm"
 			],
@@ -1516,9 +1517,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.56.0.tgz",
-			"integrity": "sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+			"integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1530,9 +1531,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.56.0.tgz",
-			"integrity": "sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+			"integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1544,9 +1545,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.56.0.tgz",
-			"integrity": "sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+			"integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1558,9 +1559,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.56.0.tgz",
-			"integrity": "sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+			"integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
 			"cpu": [
 				"loong64"
 			],
@@ -1572,9 +1573,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.56.0.tgz",
-			"integrity": "sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+			"integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
 			"cpu": [
 				"loong64"
 			],
@@ -1586,9 +1587,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.56.0.tgz",
-			"integrity": "sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+			"integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1600,9 +1601,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.56.0.tgz",
-			"integrity": "sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+			"integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1614,9 +1615,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.56.0.tgz",
-			"integrity": "sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+			"integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1628,9 +1629,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.56.0.tgz",
-			"integrity": "sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+			"integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1642,9 +1643,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.56.0.tgz",
-			"integrity": "sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+			"integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1656,9 +1657,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz",
-			"integrity": "sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+			"integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
 			"cpu": [
 				"x64"
 			],
@@ -1670,9 +1671,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.56.0.tgz",
-			"integrity": "sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+			"integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
 			"cpu": [
 				"x64"
 			],
@@ -1684,9 +1685,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.56.0.tgz",
-			"integrity": "sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+			"integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
 			"cpu": [
 				"x64"
 			],
@@ -1698,9 +1699,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.56.0.tgz",
-			"integrity": "sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+			"integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1712,9 +1713,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.56.0.tgz",
-			"integrity": "sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+			"integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1726,9 +1727,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.56.0.tgz",
-			"integrity": "sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+			"integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
 			"cpu": [
 				"ia32"
 			],
@@ -1740,9 +1741,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.56.0.tgz",
-			"integrity": "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+			"integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
 			"cpu": [
 				"x64"
 			],
@@ -1754,9 +1755,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.56.0.tgz",
-			"integrity": "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+			"integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
 			"cpu": [
 				"x64"
 			],
@@ -2392,9 +2393,9 @@
 			}
 		},
 		"node_modules/ansi-escapes": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.2.0.tgz",
-			"integrity": "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+			"integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
 			"license": "MIT",
 			"dependencies": {
 				"environment": "^1.0.0"
@@ -2874,9 +2875,9 @@
 			}
 		},
 		"node_modules/default-browser": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
 			"license": "MIT",
 			"dependencies": {
 				"bundle-name": "^4.1.0",
@@ -3146,9 +3147,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+			"integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -3159,32 +3160,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.2",
-				"@esbuild/android-arm": "0.27.2",
-				"@esbuild/android-arm64": "0.27.2",
-				"@esbuild/android-x64": "0.27.2",
-				"@esbuild/darwin-arm64": "0.27.2",
-				"@esbuild/darwin-x64": "0.27.2",
-				"@esbuild/freebsd-arm64": "0.27.2",
-				"@esbuild/freebsd-x64": "0.27.2",
-				"@esbuild/linux-arm": "0.27.2",
-				"@esbuild/linux-arm64": "0.27.2",
-				"@esbuild/linux-ia32": "0.27.2",
-				"@esbuild/linux-loong64": "0.27.2",
-				"@esbuild/linux-mips64el": "0.27.2",
-				"@esbuild/linux-ppc64": "0.27.2",
-				"@esbuild/linux-riscv64": "0.27.2",
-				"@esbuild/linux-s390x": "0.27.2",
-				"@esbuild/linux-x64": "0.27.2",
-				"@esbuild/netbsd-arm64": "0.27.2",
-				"@esbuild/netbsd-x64": "0.27.2",
-				"@esbuild/openbsd-arm64": "0.27.2",
-				"@esbuild/openbsd-x64": "0.27.2",
-				"@esbuild/openharmony-arm64": "0.27.2",
-				"@esbuild/sunos-x64": "0.27.2",
-				"@esbuild/win32-arm64": "0.27.2",
-				"@esbuild/win32-ia32": "0.27.2",
-				"@esbuild/win32-x64": "0.27.2"
+				"@esbuild/aix-ppc64": "0.27.4",
+				"@esbuild/android-arm": "0.27.4",
+				"@esbuild/android-arm64": "0.27.4",
+				"@esbuild/android-x64": "0.27.4",
+				"@esbuild/darwin-arm64": "0.27.4",
+				"@esbuild/darwin-x64": "0.27.4",
+				"@esbuild/freebsd-arm64": "0.27.4",
+				"@esbuild/freebsd-x64": "0.27.4",
+				"@esbuild/linux-arm": "0.27.4",
+				"@esbuild/linux-arm64": "0.27.4",
+				"@esbuild/linux-ia32": "0.27.4",
+				"@esbuild/linux-loong64": "0.27.4",
+				"@esbuild/linux-mips64el": "0.27.4",
+				"@esbuild/linux-ppc64": "0.27.4",
+				"@esbuild/linux-riscv64": "0.27.4",
+				"@esbuild/linux-s390x": "0.27.4",
+				"@esbuild/linux-x64": "0.27.4",
+				"@esbuild/netbsd-arm64": "0.27.4",
+				"@esbuild/netbsd-x64": "0.27.4",
+				"@esbuild/openbsd-arm64": "0.27.4",
+				"@esbuild/openbsd-x64": "0.27.4",
+				"@esbuild/openharmony-arm64": "0.27.4",
+				"@esbuild/sunos-x64": "0.27.4",
+				"@esbuild/win32-arm64": "0.27.4",
+				"@esbuild/win32-ia32": "0.27.4",
+				"@esbuild/win32-x64": "0.27.4"
 			}
 		},
 		"node_modules/escalade": {
@@ -3289,24 +3290,6 @@
 				}
 			],
 			"license": "MIT"
-		},
-		"node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/figures": {
 			"version": "6.1.0",
@@ -3810,9 +3793,9 @@
 			}
 		},
 		"node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
 			"license": "MIT",
 			"dependencies": {
 				"is-inside-container": "^1.0.0"
@@ -4285,19 +4268,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/mime": {
@@ -6752,13 +6722,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=12"
+				"node": ">=8.6"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -6789,9 +6759,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.8",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
 			"dev": true,
 			"funding": [
 				{
@@ -7047,9 +7017,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.56.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
-			"integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
+			"version": "4.60.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+			"integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7063,31 +7033,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.56.0",
-				"@rollup/rollup-android-arm64": "4.56.0",
-				"@rollup/rollup-darwin-arm64": "4.56.0",
-				"@rollup/rollup-darwin-x64": "4.56.0",
-				"@rollup/rollup-freebsd-arm64": "4.56.0",
-				"@rollup/rollup-freebsd-x64": "4.56.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.56.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.56.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.56.0",
-				"@rollup/rollup-linux-arm64-musl": "4.56.0",
-				"@rollup/rollup-linux-loong64-gnu": "4.56.0",
-				"@rollup/rollup-linux-loong64-musl": "4.56.0",
-				"@rollup/rollup-linux-ppc64-gnu": "4.56.0",
-				"@rollup/rollup-linux-ppc64-musl": "4.56.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.56.0",
-				"@rollup/rollup-linux-riscv64-musl": "4.56.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.56.0",
-				"@rollup/rollup-linux-x64-gnu": "4.56.0",
-				"@rollup/rollup-linux-x64-musl": "4.56.0",
-				"@rollup/rollup-openbsd-x64": "4.56.0",
-				"@rollup/rollup-openharmony-arm64": "4.56.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.56.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.56.0",
-				"@rollup/rollup-win32-x64-gnu": "4.56.0",
-				"@rollup/rollup-win32-x64-msvc": "4.56.0",
+				"@rollup/rollup-android-arm-eabi": "4.60.0",
+				"@rollup/rollup-android-arm64": "4.60.0",
+				"@rollup/rollup-darwin-arm64": "4.60.0",
+				"@rollup/rollup-darwin-x64": "4.60.0",
+				"@rollup/rollup-freebsd-arm64": "4.60.0",
+				"@rollup/rollup-freebsd-x64": "4.60.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.60.0",
+				"@rollup/rollup-linux-arm64-musl": "4.60.0",
+				"@rollup/rollup-linux-loong64-gnu": "4.60.0",
+				"@rollup/rollup-linux-loong64-musl": "4.60.0",
+				"@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+				"@rollup/rollup-linux-ppc64-musl": "4.60.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+				"@rollup/rollup-linux-riscv64-musl": "4.60.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.60.0",
+				"@rollup/rollup-linux-x64-gnu": "4.60.0",
+				"@rollup/rollup-linux-x64-musl": "4.60.0",
+				"@rollup/rollup-openbsd-x64": "4.60.0",
+				"@rollup/rollup-openharmony-arm64": "4.60.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.60.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.60.0",
+				"@rollup/rollup-win32-x64-gnu": "4.60.0",
+				"@rollup/rollup-win32-x64-msvc": "4.60.0",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -7917,9 +7887,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7943,6 +7913,37 @@
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
 		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tinyglobby/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/tinypool": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
@@ -7954,9 +7955,9 @@
 			}
 		},
 		"node_modules/tinyrainbow": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8041,10 +8042,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-			"integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
-			"dev": true,
+			"version": "7.22.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -8215,6 +8215,37 @@
 				}
 			}
 		},
+		"node_modules/vite/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/vitest": {
 			"version": "4.0.18",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
@@ -8291,6 +8322,19 @@
 				"jsdom": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/web-worker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
 				"semantic-release": "25.0.3",
 				"typescript": "5.9.3",
 				"vitest": "4.0.18"
+			},
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"marked": "15.0.12",
 		"marked-terminal": "7.3.0",
 		"open": "10.2.0",
+		"undici": "7.22.0",
 		"yocto-spinner": "1.0.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
 		"cli"
 	],
 	"license": "MIT",
+	"engines": {
+		"node": ">=20.18.1"
+	},
 	"dependencies": {
 		"chalk": "5.6.2",
 		"commander": "14.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       open:
         specifier: 10.2.0
         version: 10.2.0
+      undici:
+        specifier: 7.22.0
+        version: 7.22.0
       yocto-spinner:
         specifier: 1.0.0
         version: 1.0.0
@@ -774,6 +777,10 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
+
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
@@ -1469,6 +1476,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.22.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,36 +1,40 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/auth.js', () => ({
     getApiToken: () => 'test-token',
     getBaseUrl: () => 'https://test.outline.com',
 }))
 
+vi.mock('../transport/fetch-with-retry.js', () => ({
+    fetchWithRetry: vi.fn(),
+}))
+
 describe('apiRequest', () => {
-    beforeEach(() => {
-        vi.stubGlobal('fetch', vi.fn())
-    })
-
     afterEach(() => {
-        vi.unstubAllGlobals()
+        vi.clearAllMocks()
     })
 
-    it('makes POST request with correct headers', async () => {
+    it('uses fetchWithRetry for API requests', async () => {
         const mockResponse = {
             ok: true,
             json: async () => ({ data: { id: '123' } }),
         }
-        ;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        ;(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
 
         const { apiRequest } = await import('../lib/api.js')
         await apiRequest('documents.info', { id: 'abc' })
 
-        expect(fetch).toHaveBeenCalledWith('https://test.outline.com/api/documents.info', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: 'Bearer test-token',
+        expect(fetchWithRetry).toHaveBeenCalledWith({
+            url: 'https://test.outline.com/api/documents.info',
+            options: {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: 'Bearer test-token',
+                },
+                body: JSON.stringify({ id: 'abc' }),
             },
-            body: JSON.stringify({ id: 'abc' }),
         })
     })
 
@@ -42,7 +46,8 @@ describe('apiRequest', () => {
                 pagination: { offset: 0, limit: 25 },
             }),
         }
-        ;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        ;(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
 
         const { apiRequest } = await import('../lib/api.js')
         const result = await apiRequest('documents.list')
@@ -61,7 +66,8 @@ describe('apiRequest', () => {
                 message: 'Authentication required',
             }),
         }
-        ;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        ;(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
 
         const { apiRequest } = await import('../lib/api.js')
         await expect(apiRequest('auth.info')).rejects.toThrow('Authentication required')
@@ -76,7 +82,8 @@ describe('apiRequest', () => {
                 throw new Error('not json')
             },
         }
-        ;(fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        ;(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
 
         const { apiRequest } = await import('../lib/api.js')
         await expect(apiRequest('documents.list')).rejects.toThrow(

--- a/src/__tests__/fetch-with-retry.test.ts
+++ b/src/__tests__/fetch-with-retry.test.ts
@@ -1,211 +1,200 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const PROXY_ENV_KEYS = [
-	"HTTP_PROXY",
-	"http_proxy",
-	"HTTPS_PROXY",
-	"https_proxy",
-	"NO_PROXY",
-	"no_proxy",
-] as const;
+    'HTTP_PROXY',
+    'http_proxy',
+    'HTTPS_PROXY',
+    'https_proxy',
+    'NO_PROXY',
+    'no_proxy',
+] as const
 
-const originalProxyEnv = new Map(
-	PROXY_ENV_KEYS.map((key) => [key, process.env[key]]),
-);
+const originalProxyEnv = new Map(PROXY_ENV_KEYS.map((key) => [key, process.env[key]]))
 
 function clearProxyEnv(): void {
-	for (const key of PROXY_ENV_KEYS) {
-		delete process.env[key];
-	}
+    for (const key of PROXY_ENV_KEYS) {
+        delete process.env[key]
+    }
 }
 
 function restoreProxyEnv(): void {
-	for (const key of PROXY_ENV_KEYS) {
-		const value = originalProxyEnv.get(key);
-		if (value === undefined) {
-			delete process.env[key];
-			continue;
-		}
+    for (const key of PROXY_ENV_KEYS) {
+        const value = originalProxyEnv.get(key)
+        if (value === undefined) {
+            delete process.env[key]
+            continue
+        }
 
-		process.env[key] = value;
-	}
+        process.env[key] = value
+    }
 }
 
-describe("fetchWithRetry", () => {
-	beforeEach(() => {
-		clearProxyEnv();
-		vi.spyOn(process, "emitWarning").mockImplementation(() => {});
-	});
+describe('fetchWithRetry', () => {
+    beforeEach(() => {
+        clearProxyEnv()
+        vi.spyOn(process, 'emitWarning').mockImplementation(() => {})
+    })
 
-	afterEach(async () => {
-		const { resetDefaultDispatcherForTests } = await import(
-			"../transport/http-dispatcher.js"
-		);
-		await resetDefaultDispatcherForTests();
-		restoreProxyEnv();
-		vi.useRealTimers();
-		vi.unstubAllGlobals();
-		vi.restoreAllMocks();
-		vi.resetModules();
-	});
+    afterEach(async () => {
+        const { resetDefaultDispatcherForTests } = await import('../transport/http-dispatcher.js')
+        await resetDefaultDispatcherForTests()
+        restoreProxyEnv()
+        vi.useRealTimers()
+        vi.unstubAllGlobals()
+        vi.restoreAllMocks()
+        vi.resetModules()
+    })
 
-	it("uses the default dispatcher for requests", async () => {
-		const fetchMock = vi.fn();
-		fetchMock.mockResolvedValue(
-			new Response(JSON.stringify({ ok: true }), {
-				status: 200,
-				statusText: "OK",
-			}),
-		);
-		vi.stubGlobal("fetch", fetchMock);
+    it('uses the default dispatcher for requests', async () => {
+        const fetchMock = vi.fn()
+        fetchMock.mockResolvedValue(
+            new Response(JSON.stringify({ ok: true }), {
+                status: 200,
+                statusText: 'OK',
+            }),
+        )
+        vi.stubGlobal('fetch', fetchMock)
 
-		const { getDefaultDispatcher } = await import(
-			"../transport/http-dispatcher.js"
-		);
-		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
-		const response = await fetchWithRetry({
-			url: "https://test.outline.com/api/documents.info",
-			options: { method: "POST" },
-		});
+        const { getDefaultDispatcher } = await import('../transport/http-dispatcher.js')
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        const response = await fetchWithRetry({
+            url: 'https://test.outline.com/api/documents.info',
+            options: { method: 'POST' },
+        })
 
-		expect(fetchMock).toHaveBeenCalledTimes(1);
-		expect(fetchMock).toHaveBeenCalledWith(
-			"https://test.outline.com/api/documents.info",
-			{
-				method: "POST",
-				dispatcher: getDefaultDispatcher(),
-			},
-		);
-		expect(response.ok).toBe(true);
-	});
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith('https://test.outline.com/api/documents.info', {
+            method: 'POST',
+            dispatcher: getDefaultDispatcher(),
+        })
+        expect(response.ok).toBe(true)
+    })
 
-	it("retries network errors when configured", async () => {
-		const fetchMock = vi.fn();
-		fetchMock
-			.mockRejectedValueOnce(new TypeError("Failed to fetch"))
-			.mockRejectedValueOnce(new TypeError("Failed to fetch"))
-			.mockResolvedValue(
-				new Response(JSON.stringify({ ok: true }), {
-					status: 200,
-					statusText: "OK",
-				}),
-			);
-		vi.stubGlobal("fetch", fetchMock);
+    it('retries network errors when configured', async () => {
+        const fetchMock = vi.fn()
+        fetchMock
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValue(
+                new Response(JSON.stringify({ ok: true }), {
+                    status: 200,
+                    statusText: 'OK',
+                }),
+            )
+        vi.stubGlobal('fetch', fetchMock)
 
-		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
-		const response = await fetchWithRetry({
-			url: "https://test.outline.com/api/documents.info",
-			retryConfig: {
-				retries: 2,
-				retryDelay: () => 0,
-			},
-		});
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        const response = await fetchWithRetry({
+            url: 'https://test.outline.com/api/documents.info',
+            retryConfig: {
+                retries: 2,
+                retryDelay: () => 0,
+            },
+        })
 
-		expect(fetchMock).toHaveBeenCalledTimes(3);
-		expect(response.ok).toBe(true);
-	});
+        expect(fetchMock).toHaveBeenCalledTimes(3)
+        expect(response.ok).toBe(true)
+    })
 
-	it("retries timeout errors when configured", async () => {
-		vi.useFakeTimers();
+    it('retries timeout errors when configured', async () => {
+        vi.useFakeTimers()
 
-		const fetchMock = vi.fn();
-		fetchMock
-			.mockImplementationOnce(
-				(_url: RequestInfo | URL, options?: RequestInit) =>
-					new Promise<Response>((_resolve, reject) => {
-						options?.signal?.addEventListener(
-							"abort",
-							() => {
-								const reason = options.signal?.reason;
-								reject(
-									reason instanceof Error
-										? reason
-										: new Error(String(reason ?? "Request aborted")),
-								);
-							},
-							{ once: true },
-						);
-					}),
-			)
-			.mockResolvedValueOnce(
-				new Response(JSON.stringify({ ok: true }), {
-					status: 200,
-					statusText: "OK",
-				}),
-			);
-		vi.stubGlobal("fetch", fetchMock);
+        const fetchMock = vi.fn()
+        fetchMock
+            .mockImplementationOnce(
+                (_url: RequestInfo | URL, options?: RequestInit) =>
+                    new Promise<Response>((_resolve, reject) => {
+                        options?.signal?.addEventListener(
+                            'abort',
+                            () => {
+                                const reason = options.signal?.reason
+                                reject(
+                                    reason instanceof Error
+                                        ? reason
+                                        : new Error(String(reason ?? 'Request aborted')),
+                                )
+                            },
+                            { once: true },
+                        )
+                    }),
+            )
+            .mockResolvedValueOnce(
+                new Response(JSON.stringify({ ok: true }), {
+                    status: 200,
+                    statusText: 'OK',
+                }),
+            )
+        vi.stubGlobal('fetch', fetchMock)
 
-		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
-		const requestPromise = fetchWithRetry({
-			url: "https://test.outline.com/api/documents.info",
-			options: {
-				method: "GET",
-				timeout: 20,
-			},
-			retryConfig: {
-				retries: 1,
-				retryDelay: () => 0,
-			},
-		});
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        const requestPromise = fetchWithRetry({
+            url: 'https://test.outline.com/api/documents.info',
+            options: {
+                method: 'GET',
+                timeout: 20,
+            },
+            retryConfig: {
+                retries: 1,
+                retryDelay: () => 0,
+            },
+        })
 
-		await vi.advanceTimersByTimeAsync(20);
-		const response = await requestPromise;
+        await vi.advanceTimersByTimeAsync(20)
+        const response = await requestPromise
 
-		expect(fetchMock).toHaveBeenCalledTimes(2);
-		expect(response.ok).toBe(true);
-	});
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        expect(response.ok).toBe(true)
+    })
 
-	it("aborts built-in fetch requests when the timeout is reached", async () => {
-		vi.useFakeTimers();
+    it('aborts built-in fetch requests when the timeout is reached', async () => {
+        vi.useFakeTimers()
 
-		const fetchMock = vi.fn();
-		fetchMock.mockImplementation(
-			(_url: RequestInfo | URL, options?: RequestInit) =>
-				new Promise<Response>((_resolve, reject) => {
-					options?.signal?.addEventListener(
-						"abort",
-						() => {
-							const reason = options.signal?.reason;
-							reject(
-								reason instanceof Error
-									? reason
-									: new Error(String(reason ?? "Request aborted")),
-							);
-						},
-						{ once: true },
-					);
-				}),
-		);
-		vi.stubGlobal("fetch", fetchMock);
+        const fetchMock = vi.fn()
+        fetchMock.mockImplementation(
+            (_url: RequestInfo | URL, options?: RequestInit) =>
+                new Promise<Response>((_resolve, reject) => {
+                    options?.signal?.addEventListener(
+                        'abort',
+                        () => {
+                            const reason = options.signal?.reason
+                            reject(
+                                reason instanceof Error
+                                    ? reason
+                                    : new Error(String(reason ?? 'Request aborted')),
+                            )
+                        },
+                        { once: true },
+                    )
+                }),
+        )
+        vi.stubGlobal('fetch', fetchMock)
 
-		const { getDefaultDispatcher } = await import(
-			"../transport/http-dispatcher.js"
-		);
-		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
+        const { getDefaultDispatcher } = await import('../transport/http-dispatcher.js')
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
 
-		const requestPromise = fetchWithRetry({
-			url: "https://test.outline.com/api/documents.info",
-			options: {
-				method: "GET",
-				timeout: 20,
-			},
-			retryConfig: { retries: 0 },
-		});
-		const requestExpectation = expect(requestPromise).rejects.toThrow(
-			"Request timeout after 20ms",
-		);
+        const requestPromise = fetchWithRetry({
+            url: 'https://test.outline.com/api/documents.info',
+            options: {
+                method: 'GET',
+                timeout: 20,
+            },
+            retryConfig: { retries: 0 },
+        })
+        const requestExpectation = expect(requestPromise).rejects.toThrow(
+            'Request timeout after 20ms',
+        )
 
-		await vi.advanceTimersByTimeAsync(20);
-		await requestExpectation;
+        await vi.advanceTimersByTimeAsync(20)
+        await requestExpectation
 
-		expect(fetchMock).toHaveBeenCalledTimes(1);
-		expect(fetchMock).toHaveBeenCalledWith(
-			"https://test.outline.com/api/documents.info",
-			expect.objectContaining({
-				method: "GET",
-				dispatcher: getDefaultDispatcher(),
-				signal: expect.any(AbortSignal),
-			}),
-		);
-	});
-});
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://test.outline.com/api/documents.info',
+            expect.objectContaining({
+                method: 'GET',
+                dispatcher: getDefaultDispatcher(),
+                signal: expect.any(AbortSignal),
+            }),
+        )
+    })
+})

--- a/src/__tests__/fetch-with-retry.test.ts
+++ b/src/__tests__/fetch-with-retry.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const PROXY_ENV_KEYS = [
+	"HTTP_PROXY",
+	"http_proxy",
+	"HTTPS_PROXY",
+	"https_proxy",
+	"NO_PROXY",
+	"no_proxy",
+] as const;
+
+const originalProxyEnv = new Map(
+	PROXY_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function clearProxyEnv(): void {
+	for (const key of PROXY_ENV_KEYS) {
+		delete process.env[key];
+	}
+}
+
+function restoreProxyEnv(): void {
+	for (const key of PROXY_ENV_KEYS) {
+		const value = originalProxyEnv.get(key);
+		if (value === undefined) {
+			delete process.env[key];
+			continue;
+		}
+
+		process.env[key] = value;
+	}
+}
+
+describe("fetchWithRetry", () => {
+	beforeEach(() => {
+		clearProxyEnv();
+		vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+	});
+
+	afterEach(async () => {
+		const { resetDefaultDispatcherForTests } = await import(
+			"../transport/http-dispatcher.js"
+		);
+		await resetDefaultDispatcherForTests();
+		restoreProxyEnv();
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		vi.resetModules();
+	});
+
+	it("uses the default dispatcher for requests", async () => {
+		const fetchMock = vi.fn();
+		fetchMock.mockResolvedValue(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				statusText: "OK",
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { getDefaultDispatcher } = await import(
+			"../transport/http-dispatcher.js"
+		);
+		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
+		const response = await fetchWithRetry({
+			url: "https://test.outline.com/api/documents.info",
+			options: { method: "POST" },
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://test.outline.com/api/documents.info",
+			{
+				method: "POST",
+				dispatcher: getDefaultDispatcher(),
+			},
+		);
+		expect(response.ok).toBe(true);
+	});
+
+	it("retries network errors when configured", async () => {
+		const fetchMock = vi.fn();
+		fetchMock
+			.mockRejectedValueOnce(new TypeError("Failed to fetch"))
+			.mockRejectedValueOnce(new TypeError("Failed to fetch"))
+			.mockResolvedValue(
+				new Response(JSON.stringify({ ok: true }), {
+					status: 200,
+					statusText: "OK",
+				}),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
+		const response = await fetchWithRetry({
+			url: "https://test.outline.com/api/documents.info",
+			retryConfig: {
+				retries: 2,
+				retryDelay: () => 0,
+			},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(response.ok).toBe(true);
+	});
+
+	it("aborts built-in fetch requests when the timeout is reached", async () => {
+		vi.useFakeTimers();
+
+		const fetchMock = vi.fn();
+		fetchMock.mockImplementation(
+			(_url: RequestInfo | URL, options?: RequestInit) =>
+				new Promise<Response>((_resolve, reject) => {
+					options?.signal?.addEventListener(
+						"abort",
+						() => {
+							const reason = options.signal?.reason;
+							reject(
+								reason instanceof Error
+									? reason
+									: new Error(String(reason ?? "Request aborted")),
+							);
+						},
+						{ once: true },
+					);
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { getDefaultDispatcher } = await import(
+			"../transport/http-dispatcher.js"
+		);
+		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
+
+		const requestPromise = fetchWithRetry({
+			url: "https://test.outline.com/api/documents.info",
+			options: {
+				method: "GET",
+				timeout: 20,
+			},
+			retryConfig: { retries: 0 },
+		});
+		const requestExpectation = expect(requestPromise).rejects.toThrow(
+			"Request timeout after 20ms",
+		);
+
+		await vi.advanceTimersByTimeAsync(20);
+		await requestExpectation;
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://test.outline.com/api/documents.info",
+			expect.objectContaining({
+				method: "GET",
+				dispatcher: getDefaultDispatcher(),
+				signal: expect.any(AbortSignal),
+			}),
+		);
+	});
+});

--- a/src/__tests__/fetch-with-retry.test.ts
+++ b/src/__tests__/fetch-with-retry.test.ts
@@ -105,6 +105,56 @@ describe("fetchWithRetry", () => {
 		expect(response.ok).toBe(true);
 	});
 
+	it("retries timeout errors when configured", async () => {
+		vi.useFakeTimers();
+
+		const fetchMock = vi.fn();
+		fetchMock
+			.mockImplementationOnce(
+				(_url: RequestInfo | URL, options?: RequestInit) =>
+					new Promise<Response>((_resolve, reject) => {
+						options?.signal?.addEventListener(
+							"abort",
+							() => {
+								const reason = options.signal?.reason;
+								reject(
+									reason instanceof Error
+										? reason
+										: new Error(String(reason ?? "Request aborted")),
+								);
+							},
+							{ once: true },
+						);
+					}),
+			)
+			.mockResolvedValueOnce(
+				new Response(JSON.stringify({ ok: true }), {
+					status: 200,
+					statusText: "OK",
+				}),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
+		const requestPromise = fetchWithRetry({
+			url: "https://test.outline.com/api/documents.info",
+			options: {
+				method: "GET",
+				timeout: 20,
+			},
+			retryConfig: {
+				retries: 1,
+				retryDelay: () => 0,
+			},
+		});
+
+		await vi.advanceTimersByTimeAsync(20);
+		const response = await requestPromise;
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(response.ok).toBe(true);
+	});
+
 	it("aborts built-in fetch requests when the timeout is reached", async () => {
 		vi.useFakeTimers();
 

--- a/src/__tests__/http-dispatcher.test.ts
+++ b/src/__tests__/http-dispatcher.test.ts
@@ -1,0 +1,89 @@
+import { Agent, EnvHttpProxyAgent } from "undici";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const PROXY_ENV_KEYS = [
+	"HTTP_PROXY",
+	"http_proxy",
+	"HTTPS_PROXY",
+	"https_proxy",
+	"NO_PROXY",
+	"no_proxy",
+] as const;
+
+const originalProxyEnv = new Map(
+	PROXY_ENV_KEYS.map((key) => [key, process.env[key]]),
+);
+
+function clearProxyEnv(): void {
+	for (const key of PROXY_ENV_KEYS) {
+		delete process.env[key];
+	}
+}
+
+function restoreProxyEnv(): void {
+	for (const key of PROXY_ENV_KEYS) {
+		const value = originalProxyEnv.get(key);
+		if (value === undefined) {
+			delete process.env[key];
+			continue;
+		}
+
+		process.env[key] = value;
+	}
+}
+
+describe("http-dispatcher", () => {
+	beforeEach(() => {
+		clearProxyEnv();
+		vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+	});
+
+	afterEach(async () => {
+		const { resetDefaultDispatcherForTests } = await import(
+			"../transport/http-dispatcher.js"
+		);
+		await resetDefaultDispatcherForTests();
+		restoreProxyEnv();
+		vi.restoreAllMocks();
+		vi.resetModules();
+	});
+
+	it("returns a direct Agent when no proxy env vars are set", async () => {
+		const { getDefaultDispatcher } = await import(
+			"../transport/http-dispatcher.js"
+		);
+
+		expect(getDefaultDispatcher()).toBeInstanceOf(Agent);
+	});
+
+	it("returns an EnvHttpProxyAgent when proxy env vars are set", async () => {
+		process.env.HTTPS_PROXY = "http://proxy.local:8080";
+		const { getDefaultDispatcher } = await import(
+			"../transport/http-dispatcher.js"
+		);
+
+		expect(getDefaultDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
+	});
+
+	it("caches the dispatcher instance", async () => {
+		const { getDefaultDispatcher } = await import(
+			"../transport/http-dispatcher.js"
+		);
+
+		expect(getDefaultDispatcher()).toBe(getDefaultDispatcher());
+	});
+
+	it("reset lets tests re-evaluate env-dependent transport selection", async () => {
+		const { getDefaultDispatcher, resetDefaultDispatcherForTests } =
+			await import("../transport/http-dispatcher.js");
+		const directDispatcher = getDefaultDispatcher();
+
+		process.env.HTTPS_PROXY = "http://proxy.local:8080";
+		await resetDefaultDispatcherForTests();
+		const proxiedDispatcher = getDefaultDispatcher();
+
+		expect(directDispatcher).toBeInstanceOf(Agent);
+		expect(proxiedDispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+		expect(proxiedDispatcher).not.toBe(directDispatcher);
+	});
+});

--- a/src/__tests__/http-dispatcher.test.ts
+++ b/src/__tests__/http-dispatcher.test.ts
@@ -1,89 +1,79 @@
-import { Agent, EnvHttpProxyAgent } from "undici";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Agent, EnvHttpProxyAgent } from 'undici'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const PROXY_ENV_KEYS = [
-	"HTTP_PROXY",
-	"http_proxy",
-	"HTTPS_PROXY",
-	"https_proxy",
-	"NO_PROXY",
-	"no_proxy",
-] as const;
+    'HTTP_PROXY',
+    'http_proxy',
+    'HTTPS_PROXY',
+    'https_proxy',
+    'NO_PROXY',
+    'no_proxy',
+] as const
 
-const originalProxyEnv = new Map(
-	PROXY_ENV_KEYS.map((key) => [key, process.env[key]]),
-);
+const originalProxyEnv = new Map(PROXY_ENV_KEYS.map((key) => [key, process.env[key]]))
 
 function clearProxyEnv(): void {
-	for (const key of PROXY_ENV_KEYS) {
-		delete process.env[key];
-	}
+    for (const key of PROXY_ENV_KEYS) {
+        delete process.env[key]
+    }
 }
 
 function restoreProxyEnv(): void {
-	for (const key of PROXY_ENV_KEYS) {
-		const value = originalProxyEnv.get(key);
-		if (value === undefined) {
-			delete process.env[key];
-			continue;
-		}
+    for (const key of PROXY_ENV_KEYS) {
+        const value = originalProxyEnv.get(key)
+        if (value === undefined) {
+            delete process.env[key]
+            continue
+        }
 
-		process.env[key] = value;
-	}
+        process.env[key] = value
+    }
 }
 
-describe("http-dispatcher", () => {
-	beforeEach(() => {
-		clearProxyEnv();
-		vi.spyOn(process, "emitWarning").mockImplementation(() => {});
-	});
+describe('http-dispatcher', () => {
+    beforeEach(() => {
+        clearProxyEnv()
+        vi.spyOn(process, 'emitWarning').mockImplementation(() => {})
+    })
 
-	afterEach(async () => {
-		const { resetDefaultDispatcherForTests } = await import(
-			"../transport/http-dispatcher.js"
-		);
-		await resetDefaultDispatcherForTests();
-		restoreProxyEnv();
-		vi.restoreAllMocks();
-		vi.resetModules();
-	});
+    afterEach(async () => {
+        const { resetDefaultDispatcherForTests } = await import('../transport/http-dispatcher.js')
+        await resetDefaultDispatcherForTests()
+        restoreProxyEnv()
+        vi.restoreAllMocks()
+        vi.resetModules()
+    })
 
-	it("returns a direct Agent when no proxy env vars are set", async () => {
-		const { getDefaultDispatcher } = await import(
-			"../transport/http-dispatcher.js"
-		);
+    it('returns a direct Agent when no proxy env vars are set', async () => {
+        const { getDefaultDispatcher } = await import('../transport/http-dispatcher.js')
 
-		expect(getDefaultDispatcher()).toBeInstanceOf(Agent);
-	});
+        expect(getDefaultDispatcher()).toBeInstanceOf(Agent)
+    })
 
-	it("returns an EnvHttpProxyAgent when proxy env vars are set", async () => {
-		process.env.HTTPS_PROXY = "http://proxy.local:8080";
-		const { getDefaultDispatcher } = await import(
-			"../transport/http-dispatcher.js"
-		);
+    it('returns an EnvHttpProxyAgent when proxy env vars are set', async () => {
+        process.env.HTTPS_PROXY = 'http://proxy.local:8080'
+        const { getDefaultDispatcher } = await import('../transport/http-dispatcher.js')
 
-		expect(getDefaultDispatcher()).toBeInstanceOf(EnvHttpProxyAgent);
-	});
+        expect(getDefaultDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
+    })
 
-	it("caches the dispatcher instance", async () => {
-		const { getDefaultDispatcher } = await import(
-			"../transport/http-dispatcher.js"
-		);
+    it('caches the dispatcher instance', async () => {
+        const { getDefaultDispatcher } = await import('../transport/http-dispatcher.js')
 
-		expect(getDefaultDispatcher()).toBe(getDefaultDispatcher());
-	});
+        expect(getDefaultDispatcher()).toBe(getDefaultDispatcher())
+    })
 
-	it("reset lets tests re-evaluate env-dependent transport selection", async () => {
-		const { getDefaultDispatcher, resetDefaultDispatcherForTests } =
-			await import("../transport/http-dispatcher.js");
-		const directDispatcher = getDefaultDispatcher();
+    it('reset lets tests re-evaluate env-dependent transport selection', async () => {
+        const { getDefaultDispatcher, resetDefaultDispatcherForTests } =
+            await import('../transport/http-dispatcher.js')
+        const directDispatcher = getDefaultDispatcher()
 
-		process.env.HTTPS_PROXY = "http://proxy.local:8080";
-		await resetDefaultDispatcherForTests();
-		const proxiedDispatcher = getDefaultDispatcher();
+        process.env.HTTPS_PROXY = 'http://proxy.local:8080'
+        await resetDefaultDispatcherForTests()
+        const proxiedDispatcher = getDefaultDispatcher()
 
-		expect(directDispatcher).toBeInstanceOf(Agent);
-		expect(proxiedDispatcher).toBeInstanceOf(EnvHttpProxyAgent);
-		expect(proxiedDispatcher).not.toBe(directDispatcher);
-	});
-});
+        expect(directDispatcher).toBeInstanceOf(Agent)
+        expect(proxiedDispatcher).toBeInstanceOf(EnvHttpProxyAgent)
+        expect(proxiedDispatcher).not.toBe(directDispatcher)
+    })
+})

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../transport/fetch-with-retry.js", () => ({
+	fetchWithRetry: vi.fn(),
+}));
+
+describe("exchangeCodeForToken", () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("uses fetchWithRetry for token exchange", async () => {
+		const mockResponse = {
+			ok: true,
+			json: async () => ({ access_token: "test-access-token" }),
+		};
+		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
+		(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(
+			mockResponse,
+		);
+
+		const { exchangeCodeForToken } = await import("../lib/oauth.js");
+		const token = await exchangeCodeForToken({
+			baseUrl: "https://test.outline.com",
+			clientId: "client-id",
+			redirectUri: "http://localhost:3000/callback",
+			codeVerifier: "code-verifier",
+			code: "auth-code",
+		});
+
+		expect(token).toBe("test-access-token");
+		expect(fetchWithRetry).toHaveBeenCalledWith({
+			url: "https://test.outline.com/oauth/token",
+			options: {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+				},
+				body: new URLSearchParams({
+					grant_type: "authorization_code",
+					client_id: "client-id",
+					redirect_uri: "http://localhost:3000/callback",
+					code_verifier: "code-verifier",
+					code: "auth-code",
+				}).toString(),
+			},
+		});
+	});
+
+	it("throws the provider error message on failed exchange", async () => {
+		const mockResponse = {
+			ok: false,
+			statusText: "Bad Request",
+			json: async () => ({
+				error: "invalid_grant",
+				error_description: "Authorization code expired",
+			}),
+		};
+		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
+		(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(
+			mockResponse,
+		);
+
+		const { exchangeCodeForToken } = await import("../lib/oauth.js");
+		await expect(
+			exchangeCodeForToken({
+				baseUrl: "https://test.outline.com",
+				clientId: "client-id",
+				redirectUri: "http://localhost:3000/callback",
+				codeVerifier: "code-verifier",
+				code: "auth-code",
+			}),
+		).rejects.toThrow(
+			"OAuth token exchange failed: Authorization code expired",
+		);
+	});
+});

--- a/src/__tests__/oauth.test.ts
+++ b/src/__tests__/oauth.test.ts
@@ -1,77 +1,71 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock("../transport/fetch-with-retry.js", () => ({
-	fetchWithRetry: vi.fn(),
-}));
+vi.mock('../transport/fetch-with-retry.js', () => ({
+    fetchWithRetry: vi.fn(),
+}))
 
-describe("exchangeCodeForToken", () => {
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
+describe('exchangeCodeForToken', () => {
+    afterEach(() => {
+        vi.clearAllMocks()
+    })
 
-	it("uses fetchWithRetry for token exchange", async () => {
-		const mockResponse = {
-			ok: true,
-			json: async () => ({ access_token: "test-access-token" }),
-		};
-		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
-		(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(
-			mockResponse,
-		);
+    it('uses fetchWithRetry for token exchange', async () => {
+        const mockResponse = {
+            ok: true,
+            json: async () => ({ access_token: 'test-access-token' }),
+        }
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        ;(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
 
-		const { exchangeCodeForToken } = await import("../lib/oauth.js");
-		const token = await exchangeCodeForToken({
-			baseUrl: "https://test.outline.com",
-			clientId: "client-id",
-			redirectUri: "http://localhost:3000/callback",
-			codeVerifier: "code-verifier",
-			code: "auth-code",
-		});
+        const { exchangeCodeForToken } = await import('../lib/oauth.js')
+        const token = await exchangeCodeForToken({
+            baseUrl: 'https://test.outline.com',
+            clientId: 'client-id',
+            redirectUri: 'http://localhost:3000/callback',
+            codeVerifier: 'code-verifier',
+            code: 'auth-code',
+        })
 
-		expect(token).toBe("test-access-token");
-		expect(fetchWithRetry).toHaveBeenCalledWith({
-			url: "https://test.outline.com/oauth/token",
-			options: {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/x-www-form-urlencoded",
-				},
-				body: new URLSearchParams({
-					grant_type: "authorization_code",
-					client_id: "client-id",
-					redirect_uri: "http://localhost:3000/callback",
-					code_verifier: "code-verifier",
-					code: "auth-code",
-				}).toString(),
-			},
-		});
-	});
+        expect(token).toBe('test-access-token')
+        expect(fetchWithRetry).toHaveBeenCalledWith({
+            url: 'https://test.outline.com/oauth/token',
+            options: {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({
+                    grant_type: 'authorization_code',
+                    client_id: 'client-id',
+                    redirect_uri: 'http://localhost:3000/callback',
+                    code_verifier: 'code-verifier',
+                    code: 'auth-code',
+                }).toString(),
+            },
+        })
+    })
 
-	it("throws the provider error message on failed exchange", async () => {
-		const mockResponse = {
-			ok: false,
-			statusText: "Bad Request",
-			json: async () => ({
-				error: "invalid_grant",
-				error_description: "Authorization code expired",
-			}),
-		};
-		const { fetchWithRetry } = await import("../transport/fetch-with-retry.js");
-		(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(
-			mockResponse,
-		);
+    it('throws the provider error message on failed exchange', async () => {
+        const mockResponse = {
+            ok: false,
+            statusText: 'Bad Request',
+            json: async () => ({
+                error: 'invalid_grant',
+                error_description: 'Authorization code expired',
+            }),
+        }
+        const { fetchWithRetry } = await import('../transport/fetch-with-retry.js')
+        ;(fetchWithRetry as ReturnType<typeof vi.fn>).mockResolvedValue(mockResponse)
 
-		const { exchangeCodeForToken } = await import("../lib/oauth.js");
-		await expect(
-			exchangeCodeForToken({
-				baseUrl: "https://test.outline.com",
-				clientId: "client-id",
-				redirectUri: "http://localhost:3000/callback",
-				codeVerifier: "code-verifier",
-				code: "auth-code",
-			}),
-		).rejects.toThrow(
-			"OAuth token exchange failed: Authorization code expired",
-		);
-	});
-});
+        const { exchangeCodeForToken } = await import('../lib/oauth.js')
+        await expect(
+            exchangeCodeForToken({
+                baseUrl: 'https://test.outline.com',
+                clientId: 'client-id',
+                redirectUri: 'http://localhost:3000/callback',
+                codeVerifier: 'code-verifier',
+                code: 'auth-code',
+            }),
+        ).rejects.toThrow('OAuth token exchange failed: Authorization code expired')
+    })
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { fetchWithRetry } from '../transport/fetch-with-retry.js'
 import { getApiToken, getBaseUrl } from './auth.js'
 import { type SpinnerOptions, withSpinner } from './spinner.js'
 
@@ -53,13 +54,16 @@ async function rawApiRequest<T>(path: string, body: object = {}): Promise<Pagina
     const baseUrl = getBaseUrl()
     const token = getApiToken()
 
-    const res = await fetch(`${baseUrl}/api/${path}`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
+    const res = await fetchWithRetry({
+        url: `${baseUrl}/api/${path}`,
+        options: {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify(body),
         },
-        body: JSON.stringify(body),
     })
 
     if (!res.ok) {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,3 +1,5 @@
+import { fetchWithRetry } from '../transport/fetch-with-retry.js'
+
 interface AuthorizationUrlOptions {
     baseUrl: string
     clientId: string
@@ -43,12 +45,15 @@ export async function exchangeCodeForToken(options: TokenExchangeOptions): Promi
         code,
     })
 
-    const res = await fetch(`${baseUrl}/oauth/token`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
+    const res = await fetchWithRetry({
+        url: `${baseUrl}/oauth/token`,
+        options: {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: params.toString(),
         },
-        body: params.toString(),
     })
 
     const json = (await res.json()) as TokenResponse

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -22,8 +22,16 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 	retryDelay: () => 0,
 };
 
+const TIMEOUT_ERROR_NAME = "TimeoutError";
+
+function createTimeoutError(timeoutMs: number): Error {
+	const error = new Error(`Request timeout after ${timeoutMs}ms`);
+	error.name = TIMEOUT_ERROR_NAME;
+	return error;
+}
+
 function isNetworkError(error: Error): boolean {
-	return error instanceof TypeError;
+	return error instanceof TypeError || error.name === TIMEOUT_ERROR_NAME;
 }
 
 function wait(delayMs: number): Promise<void> {
@@ -39,7 +47,7 @@ function createTimeoutSignal(
 } {
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => {
-		controller.abort(new Error(`Request timeout after ${timeoutMs}ms`));
+		controller.abort(createTimeoutError(timeoutMs));
 	}, timeoutMs);
 	let abortHandler: (() => void) | undefined;
 

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -103,24 +103,21 @@ export async function fetchWithRetry(
 
 			return response;
 		} catch (error) {
+			if (clearTimeoutFn) {
+				clearTimeoutFn();
+			}
+
 			lastError = error as Error;
 			const shouldRetry =
 				attempt < config.retries && config.retryCondition(lastError);
 
 			if (!shouldRetry) {
-				if (clearTimeoutFn) {
-					clearTimeoutFn();
-				}
 				throw lastError;
 			}
 
 			const delay = config.retryDelay(attempt + 1);
 			if (delay > 0) {
 				await wait(delay);
-			}
-
-			if (clearTimeoutFn) {
-				clearTimeoutFn();
 			}
 		}
 	}

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -1,0 +1,128 @@
+import { getDefaultDispatcher } from "./http-dispatcher.js";
+
+interface RetryConfig {
+	retries: number;
+	retryCondition: (error: Error) => boolean;
+	retryDelay: (retryNumber: number) => number;
+}
+
+interface FetchOptions extends RequestInit {
+	timeout?: number;
+}
+
+interface FetchWithRetryArgs {
+	url: RequestInfo | URL;
+	options?: FetchOptions;
+	retryConfig?: Partial<RetryConfig>;
+}
+
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+	retries: 0,
+	retryCondition: isNetworkError,
+	retryDelay: () => 0,
+};
+
+function isNetworkError(error: Error): boolean {
+	return error instanceof TypeError;
+}
+
+function wait(delayMs: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function createTimeoutSignal(
+	timeoutMs: number,
+	existingSignal?: AbortSignal,
+): {
+	signal: AbortSignal;
+	clear: () => void;
+} {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => {
+		controller.abort(new Error(`Request timeout after ${timeoutMs}ms`));
+	}, timeoutMs);
+
+	function clear(): void {
+		clearTimeout(timeoutId);
+	}
+
+	if (existingSignal) {
+		if (existingSignal.aborted) {
+			clearTimeout(timeoutId);
+			controller.abort(existingSignal.reason);
+		} else {
+			existingSignal.addEventListener(
+				"abort",
+				() => {
+					clearTimeout(timeoutId);
+					controller.abort(existingSignal.reason);
+				},
+				{ once: true },
+			);
+		}
+	}
+
+	controller.signal.addEventListener("abort", () => {
+		clearTimeout(timeoutId);
+	});
+
+	return { signal: controller.signal, clear };
+}
+
+export async function fetchWithRetry(
+	args: FetchWithRetryArgs,
+): Promise<Response> {
+	const { url, options = {}, retryConfig = {} } = args;
+	const config = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+	const { timeout, signal: userSignal, ...requestOptions } = options;
+	let lastError: Error | undefined;
+
+	for (let attempt = 0; attempt <= config.retries; attempt++) {
+		let clearTimeoutFn: (() => void) | undefined;
+
+		try {
+			let requestSignal = userSignal ?? undefined;
+			if (timeout && timeout > 0) {
+				const timeoutResult = createTimeoutSignal(timeout, requestSignal);
+				requestSignal = timeoutResult.signal;
+				clearTimeoutFn = timeoutResult.clear;
+			}
+
+			const fetchOptions: RequestInit = {
+				...requestOptions,
+				signal: requestSignal,
+			};
+			// @ts-expect-error dispatcher is supported by Node.js fetch via Undici
+			fetchOptions.dispatcher = getDefaultDispatcher();
+
+			const response = await fetch(url, fetchOptions);
+			if (clearTimeoutFn) {
+				clearTimeoutFn();
+			}
+
+			return response;
+		} catch (error) {
+			lastError = error as Error;
+			const shouldRetry =
+				attempt < config.retries && config.retryCondition(lastError);
+
+			if (!shouldRetry) {
+				if (clearTimeoutFn) {
+					clearTimeoutFn();
+				}
+				throw lastError;
+			}
+
+			const delay = config.retryDelay(attempt + 1);
+			if (delay > 0) {
+				await wait(delay);
+			}
+
+			if (clearTimeoutFn) {
+				clearTimeoutFn();
+			}
+		}
+	}
+
+	throw lastError ?? new Error("Request failed after retries");
+}

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -41,9 +41,13 @@ function createTimeoutSignal(
 	const timeoutId = setTimeout(() => {
 		controller.abort(new Error(`Request timeout after ${timeoutMs}ms`));
 	}, timeoutMs);
+	let abortHandler: (() => void) | undefined;
 
 	function clear(): void {
 		clearTimeout(timeoutId);
+		if (existingSignal && abortHandler) {
+			existingSignal.removeEventListener("abort", abortHandler);
+		}
 	}
 
 	if (existingSignal) {
@@ -51,14 +55,11 @@ function createTimeoutSignal(
 			clearTimeout(timeoutId);
 			controller.abort(existingSignal.reason);
 		} else {
-			existingSignal.addEventListener(
-				"abort",
-				() => {
-					clearTimeout(timeoutId);
-					controller.abort(existingSignal.reason);
-				},
-				{ once: true },
-			);
+			abortHandler = () => {
+				clearTimeout(timeoutId);
+				controller.abort(existingSignal.reason);
+			};
+			existingSignal.addEventListener("abort", abortHandler, { once: true });
 		}
 	}
 

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -1,134 +1,131 @@
-import { getDefaultDispatcher } from "./http-dispatcher.js";
+import { getDefaultDispatcher } from './http-dispatcher.js'
 
 interface RetryConfig {
-	retries: number;
-	retryCondition: (error: Error) => boolean;
-	retryDelay: (retryNumber: number) => number;
+    retries: number
+    retryCondition: (error: Error) => boolean
+    retryDelay: (retryNumber: number) => number
 }
 
 interface FetchOptions extends RequestInit {
-	timeout?: number;
+    timeout?: number
 }
 
 interface FetchWithRetryArgs {
-	url: RequestInfo | URL;
-	options?: FetchOptions;
-	retryConfig?: Partial<RetryConfig>;
+    url: RequestInfo | URL
+    options?: FetchOptions
+    retryConfig?: Partial<RetryConfig>
 }
 
 const DEFAULT_RETRY_CONFIG: RetryConfig = {
-	retries: 0,
-	retryCondition: isNetworkError,
-	retryDelay: () => 0,
-};
+    retries: 0,
+    retryCondition: isNetworkError,
+    retryDelay: () => 0,
+}
 
-const TIMEOUT_ERROR_NAME = "TimeoutError";
+const TIMEOUT_ERROR_NAME = 'TimeoutError'
 
 function createTimeoutError(timeoutMs: number): Error {
-	const error = new Error(`Request timeout after ${timeoutMs}ms`);
-	error.name = TIMEOUT_ERROR_NAME;
-	return error;
+    const error = new Error(`Request timeout after ${timeoutMs}ms`)
+    error.name = TIMEOUT_ERROR_NAME
+    return error
 }
 
 function isNetworkError(error: Error): boolean {
-	return error instanceof TypeError || error.name === TIMEOUT_ERROR_NAME;
+    return error instanceof TypeError || error.name === TIMEOUT_ERROR_NAME
 }
 
 function wait(delayMs: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, delayMs));
+    return new Promise((resolve) => setTimeout(resolve, delayMs))
 }
 
 function createTimeoutSignal(
-	timeoutMs: number,
-	existingSignal?: AbortSignal,
+    timeoutMs: number,
+    existingSignal?: AbortSignal,
 ): {
-	signal: AbortSignal;
-	clear: () => void;
+    signal: AbortSignal
+    clear: () => void
 } {
-	const controller = new AbortController();
-	const timeoutId = setTimeout(() => {
-		controller.abort(createTimeoutError(timeoutMs));
-	}, timeoutMs);
-	let abortHandler: (() => void) | undefined;
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => {
+        controller.abort(createTimeoutError(timeoutMs))
+    }, timeoutMs)
+    let abortHandler: (() => void) | undefined
 
-	function clear(): void {
-		clearTimeout(timeoutId);
-		if (existingSignal && abortHandler) {
-			existingSignal.removeEventListener("abort", abortHandler);
-		}
-	}
+    function clear(): void {
+        clearTimeout(timeoutId)
+        if (existingSignal && abortHandler) {
+            existingSignal.removeEventListener('abort', abortHandler)
+        }
+    }
 
-	if (existingSignal) {
-		if (existingSignal.aborted) {
-			clearTimeout(timeoutId);
-			controller.abort(existingSignal.reason);
-		} else {
-			abortHandler = () => {
-				clearTimeout(timeoutId);
-				controller.abort(existingSignal.reason);
-			};
-			existingSignal.addEventListener("abort", abortHandler, { once: true });
-		}
-	}
+    if (existingSignal) {
+        if (existingSignal.aborted) {
+            clearTimeout(timeoutId)
+            controller.abort(existingSignal.reason)
+        } else {
+            abortHandler = () => {
+                clearTimeout(timeoutId)
+                controller.abort(existingSignal.reason)
+            }
+            existingSignal.addEventListener('abort', abortHandler, { once: true })
+        }
+    }
 
-	controller.signal.addEventListener("abort", () => {
-		clearTimeout(timeoutId);
-	});
+    controller.signal.addEventListener('abort', () => {
+        clearTimeout(timeoutId)
+    })
 
-	return { signal: controller.signal, clear };
+    return { signal: controller.signal, clear }
 }
 
-export async function fetchWithRetry(
-	args: FetchWithRetryArgs,
-): Promise<Response> {
-	const { url, options = {}, retryConfig = {} } = args;
-	const config = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
-	const { timeout, signal: userSignal, ...requestOptions } = options;
-	let lastError: Error | undefined;
+export async function fetchWithRetry(args: FetchWithRetryArgs): Promise<Response> {
+    const { url, options = {}, retryConfig = {} } = args
+    const config = { ...DEFAULT_RETRY_CONFIG, ...retryConfig }
+    const { timeout, signal: userSignal, ...requestOptions } = options
+    let lastError: Error | undefined
 
-	for (let attempt = 0; attempt <= config.retries; attempt++) {
-		let clearTimeoutFn: (() => void) | undefined;
+    for (let attempt = 0; attempt <= config.retries; attempt++) {
+        let clearTimeoutFn: (() => void) | undefined
 
-		try {
-			let requestSignal = userSignal ?? undefined;
-			if (timeout && timeout > 0) {
-				const timeoutResult = createTimeoutSignal(timeout, requestSignal);
-				requestSignal = timeoutResult.signal;
-				clearTimeoutFn = timeoutResult.clear;
-			}
+        try {
+            let requestSignal = userSignal ?? undefined
+            if (timeout && timeout > 0) {
+                const timeoutResult = createTimeoutSignal(timeout, requestSignal)
+                requestSignal = timeoutResult.signal
+                clearTimeoutFn = timeoutResult.clear
+            }
 
-			const fetchOptions: RequestInit = {
-				...requestOptions,
-				signal: requestSignal,
-			};
-			// @ts-expect-error dispatcher is supported by Node.js fetch via Undici
-			fetchOptions.dispatcher = getDefaultDispatcher();
+            const fetchOptions: RequestInit = {
+                ...requestOptions,
+                signal: requestSignal,
+            }
+            // @ts-expect-error dispatcher is supported by Node.js fetch via Undici
+            fetchOptions.dispatcher = getDefaultDispatcher()
 
-			const response = await fetch(url, fetchOptions);
-			if (clearTimeoutFn) {
-				clearTimeoutFn();
-			}
+            const response = await fetch(url, fetchOptions)
+            if (clearTimeoutFn) {
+                clearTimeoutFn()
+            }
 
-			return response;
-		} catch (error) {
-			if (clearTimeoutFn) {
-				clearTimeoutFn();
-			}
+            return response
+        } catch (error) {
+            if (clearTimeoutFn) {
+                clearTimeoutFn()
+            }
 
-			lastError = error as Error;
-			const shouldRetry =
-				attempt < config.retries && config.retryCondition(lastError);
+            lastError = error as Error
+            const shouldRetry = attempt < config.retries && config.retryCondition(lastError)
 
-			if (!shouldRetry) {
-				throw lastError;
-			}
+            if (!shouldRetry) {
+                throw lastError
+            }
 
-			const delay = config.retryDelay(attempt + 1);
-			if (delay > 0) {
-				await wait(delay);
-			}
-		}
-	}
+            const delay = config.retryDelay(attempt + 1)
+            if (delay > 0) {
+                await wait(delay)
+            }
+        }
+    }
 
-	throw lastError ?? new Error("Request failed after retries");
+    throw lastError ?? new Error('Request failed after retries')
 }

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -1,48 +1,43 @@
-import { Agent, type Dispatcher, EnvHttpProxyAgent } from "undici";
+import { Agent, type Dispatcher, EnvHttpProxyAgent } from 'undici'
 
 const KEEP_ALIVE_OPTIONS = {
-	keepAliveTimeout: 1,
-	keepAliveMaxTimeout: 1,
-};
+    keepAliveTimeout: 1,
+    keepAliveMaxTimeout: 1,
+}
 
-const PROXY_ENV_KEYS = [
-	"HTTPS_PROXY",
-	"https_proxy",
-	"HTTP_PROXY",
-	"http_proxy",
-] as const;
+const PROXY_ENV_KEYS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy'] as const
 
-let defaultDispatcher: Dispatcher | undefined;
+let defaultDispatcher: Dispatcher | undefined
 
 function hasProxyEnv(): boolean {
-	for (const key of PROXY_ENV_KEYS) {
-		if (process.env[key]) {
-			return true;
-		}
-	}
+    for (const key of PROXY_ENV_KEYS) {
+        if (process.env[key]) {
+            return true
+        }
+    }
 
-	return false;
+    return false
 }
 
 function createDefaultDispatcher(): Dispatcher {
-	if (hasProxyEnv()) {
-		return new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS);
-	}
+    if (hasProxyEnv()) {
+        return new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS)
+    }
 
-	return new Agent(KEEP_ALIVE_OPTIONS);
+    return new Agent(KEEP_ALIVE_OPTIONS)
 }
 
 export function getDefaultDispatcher(): Dispatcher {
-	defaultDispatcher ??= createDefaultDispatcher();
-	return defaultDispatcher;
+    defaultDispatcher ??= createDefaultDispatcher()
+    return defaultDispatcher
 }
 
 export async function resetDefaultDispatcherForTests(): Promise<void> {
-	if (!defaultDispatcher) {
-		return;
-	}
+    if (!defaultDispatcher) {
+        return
+    }
 
-	const dispatcher = defaultDispatcher;
-	defaultDispatcher = undefined;
-	await dispatcher.close();
+    const dispatcher = defaultDispatcher
+    defaultDispatcher = undefined
+    await dispatcher.close()
 }

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -1,0 +1,48 @@
+import { Agent, type Dispatcher, EnvHttpProxyAgent } from "undici";
+
+const KEEP_ALIVE_OPTIONS = {
+	keepAliveTimeout: 1,
+	keepAliveMaxTimeout: 1,
+};
+
+const PROXY_ENV_KEYS = [
+	"HTTPS_PROXY",
+	"https_proxy",
+	"HTTP_PROXY",
+	"http_proxy",
+] as const;
+
+let defaultDispatcher: Dispatcher | undefined;
+
+function hasProxyEnv(): boolean {
+	for (const key of PROXY_ENV_KEYS) {
+		if (process.env[key]) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+function createDefaultDispatcher(): Dispatcher {
+	if (hasProxyEnv()) {
+		return new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS);
+	}
+
+	return new Agent(KEEP_ALIVE_OPTIONS);
+}
+
+export function getDefaultDispatcher(): Dispatcher {
+	defaultDispatcher ??= createDefaultDispatcher();
+	return defaultDispatcher;
+}
+
+export async function resetDefaultDispatcherForTests(): Promise<void> {
+	if (!defaultDispatcher) {
+		return;
+	}
+
+	const dispatcher = defaultDispatcher;
+	defaultDispatcher = undefined;
+	await dispatcher.close();
+}


### PR DESCRIPTION
Makes the HTTP client honor `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` by default for its built-in network requests.