### PR TITLE
feat: add --parent option to doc create and doc move

### DIFF
--- a/skills/outline-cli/SKILL.md
+++ b/skills/outline-cli/SKILL.md
@@ -50,13 +50,12 @@ ol doc get <id> --raw                     # Raw markdown
 ol doc get <id> --json
 ol doc open <id>                          # Open in browser
 ol doc create --title "Title" --collection <id> --text "# Content"
-ol doc create --title "Title" --collection <id> --parent <ref>  # Nest under parent
+ol doc create --title "Title" --parent <ref> --text "# Content"  # Nest under parent (collection inferred)
 ol doc create --title "Title" --collection <id> --file ./doc.md
 ol doc update <id> --title "New Title"
 ol doc update <id> --file ./updated.md
-ol doc move <id> --collection <target-id>
-ol doc move <id> --parent <ref>                   # Nest under parent in same collection
-ol doc move <id> --collection <id> --parent <ref>  # Move to collection under parent
+ol doc move <id> --collection <target-id>           # Move to collection root
+ol doc move <id> --parent <ref>                    # Nest under parent (collection inferred)
 ol doc archive <id>
 ol doc unarchive <id>
 ol doc delete <id> --confirm

--- a/skills/outline-cli/SKILL.md
+++ b/skills/outline-cli/SKILL.md
@@ -50,10 +50,13 @@ ol doc get <id> --raw                     # Raw markdown
 ol doc get <id> --json
 ol doc open <id>                          # Open in browser
 ol doc create --title "Title" --collection <id> --text "# Content"
+ol doc create --title "Title" --collection <id> --parent <ref>  # Nest under parent
 ol doc create --title "Title" --collection <id> --file ./doc.md
 ol doc update <id> --title "New Title"
 ol doc update <id> --file ./updated.md
 ol doc move <id> --collection <target-id>
+ol doc move <id> --parent <ref>                   # Nest under parent in same collection
+ol doc move <id> --collection <id> --parent <ref>  # Move to collection under parent
 ol doc archive <id>
 ol doc unarchive <id>
 ol doc delete <id> --confirm

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -155,6 +155,177 @@ describe('document commands', () => {
             direction: 'DESC',
         })
     })
+
+    it('document create with --parent includes parentDocumentId', async () => {
+        const { apiRequest } = await import('../lib/api.js')
+        const mockApiRequest = apiRequest as ReturnType<typeof vi.fn>
+        mockApiRequest.mockImplementation((endpoint: string, body: Record<string, unknown>) => {
+            if (endpoint === 'collections.info') {
+                return Promise.resolve({
+                    data: { id: body.id, name: 'Test Collection' },
+                })
+            }
+            if (endpoint === 'documents.info') {
+                return Promise.resolve({
+                    data: {
+                        id: body.id,
+                        title: 'Parent',
+                        urlId: 'parent-abc',
+                        url: '/doc/parent',
+                    },
+                })
+            }
+            if (endpoint === 'documents.create') {
+                return Promise.resolve({
+                    data: {
+                        id: 'new-id',
+                        title: 'Child',
+                        urlId: 'child-xyz',
+                        collectionId: 'colABC1',
+                        updatedAt: '2024-01-01T00:00:00Z',
+                    },
+                })
+            }
+            return Promise.reject(new Error(`Unexpected endpoint: ${endpoint}`))
+        })
+
+        const { registerDocumentCommand } = await import('../commands/document.js')
+        const program = new Command()
+        program.exitOverride()
+        registerDocumentCommand(program)
+
+        await program.parseAsync([
+            'node',
+            'ol',
+            'document',
+            'create',
+            '--title',
+            'Child',
+            '--collection',
+            'colABC1',
+            '--parent',
+            'parentA1',
+        ])
+
+        expect(mockApiRequest).toHaveBeenCalledWith('documents.create', {
+            title: 'Child',
+            collectionId: 'colABC1',
+            parentDocumentId: 'parentA1',
+        })
+    })
+
+    it('document move with --parent only sends parentDocumentId without collectionId', async () => {
+        const { apiRequest } = await import('../lib/api.js')
+        const mockApiRequest = apiRequest as ReturnType<typeof vi.fn>
+        mockApiRequest.mockImplementation((endpoint: string, body: Record<string, unknown>) => {
+            if (endpoint === 'documents.info') {
+                return Promise.resolve({
+                    data: {
+                        id: body.id,
+                        title: 'Doc',
+                        urlId: 'doc-abc',
+                        url: '/doc',
+                    },
+                })
+            }
+            if (endpoint === 'documents.move') {
+                return Promise.resolve({ data: {} })
+            }
+            return Promise.reject(new Error(`Unexpected endpoint: ${endpoint}`))
+        })
+
+        const { registerDocumentCommand } = await import('../commands/document.js')
+        const program = new Command()
+        program.exitOverride()
+        registerDocumentCommand(program)
+
+        await program.parseAsync([
+            'node',
+            'ol',
+            'document',
+            'move',
+            'docABC1',
+            '--parent',
+            'parentA1',
+        ])
+
+        expect(mockApiRequest).toHaveBeenCalledWith('documents.move', {
+            id: 'docABC1',
+            parentDocumentId: 'parentA1',
+        })
+    })
+
+    it('document move with --collection and --parent sends both', async () => {
+        const { apiRequest } = await import('../lib/api.js')
+        const mockApiRequest = apiRequest as ReturnType<typeof vi.fn>
+        mockApiRequest.mockImplementation((endpoint: string, body: Record<string, unknown>) => {
+            if (endpoint === 'collections.info') {
+                return Promise.resolve({
+                    data: { id: body.id, name: 'Target' },
+                })
+            }
+            if (endpoint === 'documents.info') {
+                return Promise.resolve({
+                    data: {
+                        id: body.id,
+                        title: 'Doc',
+                        urlId: 'doc-abc',
+                        url: '/doc',
+                    },
+                })
+            }
+            if (endpoint === 'documents.move') {
+                return Promise.resolve({ data: {} })
+            }
+            return Promise.reject(new Error(`Unexpected endpoint: ${endpoint}`))
+        })
+
+        const { registerDocumentCommand } = await import('../commands/document.js')
+        const program = new Command()
+        program.exitOverride()
+        registerDocumentCommand(program)
+
+        await program.parseAsync([
+            'node',
+            'ol',
+            'document',
+            'move',
+            'docABC1',
+            '--collection',
+            'colABC1',
+            '--parent',
+            'parentA1',
+        ])
+
+        expect(mockApiRequest).toHaveBeenCalledWith('documents.move', {
+            id: 'docABC1',
+            collectionId: 'colABC1',
+            parentDocumentId: 'parentA1',
+        })
+    })
+
+    it('document move without --collection or --parent errors', async () => {
+        const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+            throw new Error(`process.exit(${code})`)
+        })
+        const errors: string[] = []
+        vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+            errors.push(args.join(' '))
+        })
+
+        const { registerDocumentCommand } = await import('../commands/document.js')
+        const program = new Command()
+        program.exitOverride()
+        registerDocumentCommand(program)
+
+        await expect(
+            program.parseAsync(['node', 'ol', 'document', 'move', 'docABC1']),
+        ).rejects.toThrow('process.exit(1)')
+
+        expect(errors.join(' ')).toContain('--collection')
+        expect(errors.join(' ')).toContain('--parent')
+        mockExit.mockRestore()
+    })
 })
 
 describe('collection commands', () => {

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -156,15 +156,10 @@ describe('document commands', () => {
         })
     })
 
-    it('document create with --parent includes parentDocumentId', async () => {
+    it('document create with --parent infers collectionId from parent', async () => {
         const { apiRequest } = await import('../lib/api.js')
         const mockApiRequest = apiRequest as ReturnType<typeof vi.fn>
         mockApiRequest.mockImplementation((endpoint: string, body: Record<string, unknown>) => {
-            if (endpoint === 'collections.info') {
-                return Promise.resolve({
-                    data: { id: body.id, name: 'Test Collection' },
-                })
-            }
             if (endpoint === 'documents.info') {
                 return Promise.resolve({
                     data: {
@@ -172,6 +167,7 @@ describe('document commands', () => {
                         title: 'Parent',
                         urlId: 'parent-abc',
                         url: '/doc/parent',
+                        collectionId: 'inferred-col',
                     },
                 })
             }
@@ -181,7 +177,7 @@ describe('document commands', () => {
                         id: 'new-id',
                         title: 'Child',
                         urlId: 'child-xyz',
-                        collectionId: 'colABC1',
+                        collectionId: 'inferred-col',
                         updatedAt: '2024-01-01T00:00:00Z',
                     },
                 })
@@ -201,20 +197,51 @@ describe('document commands', () => {
             'create',
             '--title',
             'Child',
-            '--collection',
-            'colABC1',
             '--parent',
             'parentA1',
         ])
 
         expect(mockApiRequest).toHaveBeenCalledWith('documents.create', {
             title: 'Child',
-            collectionId: 'colABC1',
+            collectionId: 'inferred-col',
             parentDocumentId: 'parentA1',
         })
     })
 
-    it('document move with --parent only sends parentDocumentId without collectionId', async () => {
+    it('document create with both --collection and --parent errors', async () => {
+        const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+            throw new Error(`process.exit(${code})`)
+        })
+        const errors: string[] = []
+        vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+            errors.push(args.join(' '))
+        })
+
+        const { registerDocumentCommand } = await import('../commands/document.js')
+        const program = new Command()
+        program.exitOverride()
+        registerDocumentCommand(program)
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'ol',
+                'document',
+                'create',
+                '--title',
+                'Test',
+                '--collection',
+                'colABC1',
+                '--parent',
+                'parentA1',
+            ]),
+        ).rejects.toThrow('process.exit(1)')
+
+        expect(errors.join(' ')).toContain('mutually exclusive')
+        mockExit.mockRestore()
+    })
+
+    it('document move with --parent infers collectionId from parent', async () => {
         const { apiRequest } = await import('../lib/api.js')
         const mockApiRequest = apiRequest as ReturnType<typeof vi.fn>
         mockApiRequest.mockImplementation((endpoint: string, body: Record<string, unknown>) => {
@@ -225,6 +252,7 @@ describe('document commands', () => {
                         title: 'Doc',
                         urlId: 'doc-abc',
                         url: '/doc',
+                        collectionId: 'parent-col',
                     },
                 })
             }
@@ -251,33 +279,18 @@ describe('document commands', () => {
 
         expect(mockApiRequest).toHaveBeenCalledWith('documents.move', {
             id: 'docABC1',
+            collectionId: 'parent-col',
             parentDocumentId: 'parentA1',
         })
     })
 
-    it('document move with --collection and --parent sends both', async () => {
-        const { apiRequest } = await import('../lib/api.js')
-        const mockApiRequest = apiRequest as ReturnType<typeof vi.fn>
-        mockApiRequest.mockImplementation((endpoint: string, body: Record<string, unknown>) => {
-            if (endpoint === 'collections.info') {
-                return Promise.resolve({
-                    data: { id: body.id, name: 'Target' },
-                })
-            }
-            if (endpoint === 'documents.info') {
-                return Promise.resolve({
-                    data: {
-                        id: body.id,
-                        title: 'Doc',
-                        urlId: 'doc-abc',
-                        url: '/doc',
-                    },
-                })
-            }
-            if (endpoint === 'documents.move') {
-                return Promise.resolve({ data: {} })
-            }
-            return Promise.reject(new Error(`Unexpected endpoint: ${endpoint}`))
+    it('document move with both --collection and --parent errors', async () => {
+        const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+            throw new Error(`process.exit(${code})`)
+        })
+        const errors: string[] = []
+        vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+            errors.push(args.join(' '))
         })
 
         const { registerDocumentCommand } = await import('../commands/document.js')
@@ -285,23 +298,22 @@ describe('document commands', () => {
         program.exitOverride()
         registerDocumentCommand(program)
 
-        await program.parseAsync([
-            'node',
-            'ol',
-            'document',
-            'move',
-            'docABC1',
-            '--collection',
-            'colABC1',
-            '--parent',
-            'parentA1',
-        ])
+        await expect(
+            program.parseAsync([
+                'node',
+                'ol',
+                'document',
+                'move',
+                'docABC1',
+                '--collection',
+                'colABC1',
+                '--parent',
+                'parentA1',
+            ]),
+        ).rejects.toThrow('process.exit(1)')
 
-        expect(mockApiRequest).toHaveBeenCalledWith('documents.move', {
-            id: 'docABC1',
-            collectionId: 'colABC1',
-            parentDocumentId: 'parentA1',
-        })
+        expect(errors.join(' ')).toContain('mutually exclusive')
+        mockExit.mockRestore()
     })
 
     it('document move without --collection or --parent errors', async () => {

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -338,6 +338,53 @@ describe('document commands', () => {
         expect(errors.join(' ')).toContain('--parent')
         mockExit.mockRestore()
     })
+
+    it('document move with --parent pointing to itself errors', async () => {
+        const { apiRequest } = await import('../lib/api.js')
+        const mockApiRequest = apiRequest as ReturnType<typeof vi.fn>
+        mockApiRequest.mockImplementation((endpoint: string) => {
+            if (endpoint === 'documents.info') {
+                return Promise.resolve({
+                    data: {
+                        id: 'sameDoc1',
+                        title: 'Doc',
+                        urlId: 'doc-abc',
+                        url: '/doc',
+                        collectionId: 'col-1',
+                    },
+                })
+            }
+            return Promise.reject(new Error(`Unexpected endpoint: ${endpoint}`))
+        })
+
+        const mockExit = vi.spyOn(process, 'exit').mockImplementation((code) => {
+            throw new Error(`process.exit(${code})`)
+        })
+        const errors: string[] = []
+        vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+            errors.push(args.join(' '))
+        })
+
+        const { registerDocumentCommand } = await import('../commands/document.js')
+        const program = new Command()
+        program.exitOverride()
+        registerDocumentCommand(program)
+
+        await expect(
+            program.parseAsync([
+                'node',
+                'ol',
+                'document',
+                'move',
+                'sameDoc1',
+                '--parent',
+                'sameDoc1',
+            ]),
+        ).rejects.toThrow('process.exit(1)')
+
+        expect(errors.join(' ')).toContain('cannot be its own parent')
+        mockExit.mockRestore()
+    })
 })
 
 describe('collection commands', () => {

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -135,7 +135,7 @@ export function registerDocumentCommand(program: Command): void {
                         'Either --collection or --parent must be provided.',
                         [
                             'Use --collection to create at a collection root',
-                            'Use --parent to nest under a parent document',
+                            'Use --parent to nest under a parent document (collection is inferred)',
                         ],
                     ),
                 )

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -270,6 +270,12 @@ export function registerDocumentCommand(program: Command): void {
             }
             if (opts.parent) {
                 const parent = await resolveDocumentRef(opts.parent)
+                if (parent.id === resolvedId) {
+                    console.error(
+                        formatError('INVALID_PARENT', 'A document cannot be its own parent.', []),
+                    )
+                    process.exit(1)
+                }
                 body.parentDocumentId = parent.id
                 body.collectionId = (parent as Document).collectionId
             }

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -121,21 +121,52 @@ export function registerDocumentCommand(program: Command): void {
     doc.command('create')
         .description('Create a document')
         .requiredOption('--title <title>', 'Document title')
-        .requiredOption('--collection <ref>', 'Collection ID or name')
+        .option('--collection <ref>', 'Collection ID or name')
         .option('--parent <ref>', 'Parent document ID, URL, or name')
         .option('--text <text>', 'Document body (markdown)')
         .option('--file <path>', 'Read markdown from file')
         .option('--publish', 'Publish immediately')
         .option('--json', 'Output JSON')
         .action(async (opts) => {
-            const collectionId = await resolveCollectionId(opts.collection)
+            if (!opts.collection && !opts.parent) {
+                console.error(
+                    formatError(
+                        'MISSING_OPTION',
+                        'Either --collection or --parent must be provided.',
+                        [
+                            'Use --collection to create at a collection root',
+                            'Use --parent to nest under a parent document',
+                        ],
+                    ),
+                )
+                process.exit(1)
+            }
+            if (opts.collection && opts.parent) {
+                console.error(
+                    formatError(
+                        'CONFLICTING_OPTIONS',
+                        '--collection and --parent are mutually exclusive.',
+                        [
+                            'Use --collection to create at a collection root',
+                            'Use --parent to nest under a parent document (collection is inferred)',
+                        ],
+                    ),
+                )
+                process.exit(1)
+            }
+
             const body: Record<string, unknown> = {
                 title: opts.title,
-                collectionId,
+            }
+
+            if (opts.collection) {
+                body.collectionId = await resolveCollectionId(opts.collection)
             }
 
             if (opts.parent) {
-                body.parentDocumentId = await resolveDocumentId(opts.parent)
+                const parent = await resolveDocumentRef(opts.parent)
+                body.parentDocumentId = parent.id
+                body.collectionId = (parent as Document).collectionId
             }
 
             const text = readTextInput(opts)
@@ -208,10 +239,23 @@ export function registerDocumentCommand(program: Command): void {
                 console.error(
                     formatError(
                         'MISSING_OPTION',
-                        'At least one of --collection or --parent must be provided.',
+                        'Either --collection or --parent must be provided.',
                         [
-                            'Use --collection to move to another collection',
+                            'Use --collection to move to a collection root',
                             'Use --parent to nest under a parent document',
+                        ],
+                    ),
+                )
+                process.exit(1)
+            }
+            if (opts.collection && opts.parent) {
+                console.error(
+                    formatError(
+                        'CONFLICTING_OPTIONS',
+                        '--collection and --parent are mutually exclusive.',
+                        [
+                            'Use --collection to move to a collection root',
+                            'Use --parent to nest under a parent document (collection is inferred)',
                         ],
                     ),
                 )
@@ -225,7 +269,9 @@ export function registerDocumentCommand(program: Command): void {
                 body.collectionId = await resolveCollectionId(opts.collection)
             }
             if (opts.parent) {
-                body.parentDocumentId = await resolveDocumentId(opts.parent)
+                const parent = await resolveDocumentRef(opts.parent)
+                body.parentDocumentId = parent.id
+                body.collectionId = (parent as Document).collectionId
             }
 
             await apiRequest('documents.move', body)

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -242,7 +242,7 @@ export function registerDocumentCommand(program: Command): void {
                         'Either --collection or --parent must be provided.',
                         [
                             'Use --collection to move to a collection root',
-                            'Use --parent to nest under a parent document',
+                            'Use --parent to nest under a parent document (collection is inferred)',
                         ],
                     ),
                 )

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -122,6 +122,7 @@ export function registerDocumentCommand(program: Command): void {
         .description('Create a document')
         .requiredOption('--title <title>', 'Document title')
         .requiredOption('--collection <ref>', 'Collection ID or name')
+        .option('--parent <ref>', 'Parent document ID, URL, or name')
         .option('--text <text>', 'Document body (markdown)')
         .option('--file <path>', 'Read markdown from file')
         .option('--publish', 'Publish immediately')
@@ -131,6 +132,10 @@ export function registerDocumentCommand(program: Command): void {
             const body: Record<string, unknown> = {
                 title: opts.title,
                 collectionId,
+            }
+
+            if (opts.parent) {
+                body.parentDocumentId = await resolveDocumentId(opts.parent)
             }
 
             const text = readTextInput(opts)
@@ -195,15 +200,35 @@ export function registerDocumentCommand(program: Command): void {
         })
 
     doc.command('move <id>')
-        .description('Move a document to another collection')
-        .requiredOption('--collection <ref>', 'Target collection ID or name')
+        .description('Move a document to another collection or under a parent')
+        .option('--collection <ref>', 'Target collection ID or name')
+        .option('--parent <ref>', 'Parent document ID, URL, or name')
         .action(async (id: string, opts) => {
+            if (!opts.collection && !opts.parent) {
+                console.error(
+                    formatError(
+                        'MISSING_OPTION',
+                        'At least one of --collection or --parent must be provided.',
+                        [
+                            'Use --collection to move to another collection',
+                            'Use --parent to nest under a parent document',
+                        ],
+                    ),
+                )
+                process.exit(1)
+            }
+
             const resolvedId = await resolveDocumentId(id)
-            const collectionId = await resolveCollectionId(opts.collection)
-            await apiRequest('documents.move', {
-                id: resolvedId,
-                collectionId,
-            })
+            const body: Record<string, unknown> = { id: resolvedId }
+
+            if (opts.collection) {
+                body.collectionId = await resolveCollectionId(opts.collection)
+            }
+            if (opts.parent) {
+                body.parentDocumentId = await resolveDocumentId(opts.parent)
+            }
+
+            await apiRequest('documents.move', body)
             console.log('Moved.')
         })
 

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -49,10 +49,13 @@ ol doc get <id> --raw                     # Raw markdown
 ol doc get <id> --json
 ol doc open <id>                          # Open in browser
 ol doc create --title "Title" --collection <id> --text "# Content"
+ol doc create --title "Title" --collection <id> --parent <ref>  # Nest under parent
 ol doc create --title "Title" --collection <id> --file ./doc.md
 ol doc update <id> --title "New Title"
 ol doc update <id> --file ./updated.md
 ol doc move <id> --collection <target-id>
+ol doc move <id> --parent <ref>                   # Nest under parent in same collection
+ol doc move <id> --collection <id> --parent <ref>  # Move to collection under parent
 ol doc archive <id>
 ol doc unarchive <id>
 ol doc delete <id> --confirm

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -49,13 +49,12 @@ ol doc get <id> --raw                     # Raw markdown
 ol doc get <id> --json
 ol doc open <id>                          # Open in browser
 ol doc create --title "Title" --collection <id> --text "# Content"
-ol doc create --title "Title" --collection <id> --parent <ref>  # Nest under parent
+ol doc create --title "Title" --parent <ref> --text "# Content"  # Nest under parent (collection inferred)
 ol doc create --title "Title" --collection <id> --file ./doc.md
 ol doc update <id> --title "New Title"
 ol doc update <id> --file ./updated.md
-ol doc move <id> --collection <target-id>
-ol doc move <id> --parent <ref>                   # Nest under parent in same collection
-ol doc move <id> --collection <id> --parent <ref>  # Move to collection under parent
+ol doc move <id> --collection <target-id>           # Move to collection root
+ol doc move <id> --parent <ref>                    # Nest under parent (collection inferred)
 ol doc archive <id>
 ol doc unarchive <id>
 ol doc delete <id> --confirm


### PR DESCRIPTION
## Overview

While working with an agent to create a new document in the Doist handbook, we hit a limitation: the CLI had no way to place a document under a parent. The document got created at the collection root, and then had to be manually moved into the correct position in the document tree through the Outline UI. The same gap existed for `doc move` — you could move a document to a different collection, but not nest it under a specific parent.

This PR adds a `--parent <ref>` option to both `ol doc create` and `ol doc move`. When `--parent` is provided, the collection is automatically inferred from the parent document, so you don't need to know or specify which collection the parent lives in. The two options are mutually exclusive: `--collection` places a document at a collection root, `--parent` nests it under a parent.

## Test plan

> [!NOTE]
> This test plan requires the project to be checked out and configured with the Outline API credentials. Set `export OUTLINE_URL="https://handbook.doist.com"` and `export OUTLINE_API_TOKEN` with a token retrieved from your account settings before running.

> [!TIP]
> Consider running this test plan with the help of a coding agent, asking it to execute each step and pause between them for manual validation in the Outline UI — this makes it much easier to track IDs and verify results as you go.

```bash
npm run build
```

**Setup: create a test collection and parent document**

```bash
node dist/index.js col create --name "CLI parent test" --json
# Note the collection id

node dist/index.js doc create --title "Test parent" \
  --collection <collection-id> --text "Parent doc" --publish --json
# Note the parent urlId
```

**1. Create a nested document using --parent**

```bash
node dist/index.js doc create --title "Nested child" \
  --parent <parent-urlId> \
  --text "Created via --parent" --publish
```

Verify in the UI that the document appears nested under "Test parent".

**2a. Create a document at the collection root**

```bash
node dist/index.js doc create --title "Move target" \
  --collection <collection-id> \
  --text "Will be moved" --publish --json
# Note the urlId
```

Verify in the UI that the document appears at the collection root, not nested.

**2b. Move it under the parent**

```bash
node dist/index.js doc move <urlId> --parent <parent-urlId>
```

Verify in the UI it is now nested under "Test parent".

**3. Mutual exclusivity**

```bash
# Both options together should error
node dist/index.js doc create --title "Fail" \
  --collection <collection-id> --parent <parent-urlId>

# Neither option should error
node dist/index.js doc move <urlId>
```

**Cleanup**

```bash
node dist/index.js doc delete <nested-child-urlId> --confirm
node dist/index.js doc delete <move-target-urlId> --confirm
node dist/index.js doc delete <parent-urlId> --confirm
node dist/index.js col delete <collection-id> --confirm
```
