### PR TITLE
ci: add next branch for pre-release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
             - name: Capture previous tag
               if: github.ref_name == 'main'
               id: previous_tag
-              run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
+              run: echo "tag=$(git describe --tags --abbrev=0 --exclude='*-*' 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
 
             - name: Release
               run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 # Release involves crucial steps that shouldn't be cancelled mid-run,
 # so new workflow runs are queued until the previous one finishes.
 concurrency:
-    group: ${{ github.workflow }}
+    group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches:
             - main
+            - next
 
 permissions:
     # Enable `semantic-release` to publish a GitHub release and push commits
@@ -68,6 +69,7 @@ jobs:
               run: npm ci
 
             - name: Capture previous tag
+              if: github.ref_name == 'main'
               id: previous_tag
               run: echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || true)" >> "$GITHUB_OUTPUT"
 
@@ -81,6 +83,7 @@ jobs:
                   GIT_COMMITTER_EMAIL: ${{ steps.bot_user.outputs.id }}+${{ steps.generate_token.outputs.app-slug }}[bot]@users.noreply.github.com
 
             - name: Derive release announcement
+              if: github.ref_name == 'main'
               id: announcement
               env:
                   PREVIOUS_TAG: ${{ steps.previous_tag.outputs.tag }}
@@ -124,7 +127,7 @@ jobs:
                   } >> "$GITHUB_OUTPUT"
 
             - name: Announce release in Twist
-              if: ${{ steps.announcement.outputs.should_announce == 'true' }}
+              if: github.ref_name == 'main' && steps.announcement.outputs.should_announce == 'true'
               uses: Doist/twist-post-action@74a0255b75ad93c06b9eb1009960106efe13f5ca
               with:
                   message: ${{ steps.announcement.outputs.message }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to Outline CLI
+
+The following is a set of guidelines for contributing to Outline CLI. Please read these guidelines before creating an issue or pull request.
+
+## Open Development
+
+All work on Outline CLI happens directly on [GitHub](https://github.com/Doist/outline-cli). Both core team members and external contributors send pull requests that go through the same review process.
+
+## Semantic Versioning
+
+Outline CLI follows [semantic versioning](https://semver.org/). We release patch versions for bugfixes, minor versions for new features or non-essential changes, and major versions for any breaking changes.
+
+Every significant change is documented in the [CHANGELOG.md](CHANGELOG.md) file.
+
+## Branch Organization
+
+Submit all changes directly to the [main](https://github.com/Doist/outline-cli/tree/main) branch (via PR). We do our best to keep `main` in good shape, with all tests passing.
+
+For pre-release testing, the `next` branch is used to publish pre-release versions to npm before promoting to stable. See [Release Process](#release-process-core-team-only) for details.
+
+## Development Workflow
+
+After cloning the repository and installing dependencies with `npm install`, several commands are at your disposal:
+
+- `npm run build`: Builds the CLI
+- `npm run dev`: Runs in development mode
+- `npm run lint:check`: Validates code quality
+- `npm run lint:write`: Auto-fixes lint issues
+- `npm run format:check`: Checks formatting
+- `npm run format`: Auto-fixes formatting
+- `npm test`: Runs all tests
+- `npm run test:watch`: Runs tests in watch mode
+
+## Sending a Pull Request
+
+Before submitting a pull request, please take the following into consideration:
+
+- Create your branch from `main` (or from `next` if working on a pre-release feature)
+- Follow the [Commit Message Guidelines](#commit-message-guidelines) below
+- Add tests for code that should be tested
+- Ensure the test suite passes
+- Do not override built-in validation and formatting checks
+
+## Commit Message Guidelines
+
+### Commit Message Format
+
+This repository expects all commit messages to follow the [Conventional Commits Specification](https://www.conventionalcommits.org/) to automate semantic versioning and changelog generation.
+
+Each commit message consists of a **header**, an **optional body**, and an **optional footer**:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Commit types such as `feat:` and `fix:` affect versioning and changelog generation. Other types like `build:`, `chore:`, `ci:`, `docs:`, `perf:`, `refactor:`, `revert:`, `style:` and `test:` are valid but will not trigger a release.
+
+A commit that has the text `BREAKING CHANGE:` at the beginning of its optional body or footer, or appends a `!` after the type/scope, introduces a breaking API change (correlating with `MAJOR` in semantic versioning).
+
+### Semantic Pull Request Validation
+
+PR titles are validated against the Conventional Commits format by CI. When squash-merging, the PR title becomes the commit message, so ensure it follows the format (e.g., `feat: add new endpoint`, `fix: correct pagination`).
+
+## Release Process (core team only)
+
+The release process is fully automated with [semantic-release](https://github.com/semantic-release/semantic-release). Pushing to `main` (after CI passes) triggers a stable release automatically.
+
+### Pre-releases
+
+To test features before publishing a stable release:
+
+1. **Sync `next` with `main`** before starting new work, and after each stable release (required for semantic-release to correctly initiate the next pre-release versioning cycle):
+
+    ```sh
+    git checkout next
+    git merge main -m "chore: sync next with main [skip ci]"
+    git push origin next
+    ```
+
+2. **Develop on a feature branch** based off `next` and open a PR targeting `next`.
+
+3. **Automatic pre-release:** Each PR merge into `next` triggers CI and publishes a pre-release version (e.g., `1.1.0-next.1`) to the `@next` dist-tag on npm.
+
+4. **Promote to stable:** When ready, open a PR to merge `next` into `main`. The PR title must follow Conventional Commits (e.g., `feat: ...`, `fix: ...`) as it determines the version bump for the stable release.
+
+> **Note:** The `CHANGELOG.md` is only updated for stable releases on `main`. Pre-releases still get GitHub release notes and npm publication.
+
+### Installing a pre-release
+
+```sh
+npm install @doist/outline-cli@next
+```
+
+## License
+
+By contributing to Outline CLI, you agree that your contributions will be licensed under its [MIT license](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Each commit message consists of a **header**, an **optional body**, and an **opt
 [optional footer(s)]
 ```
 
-Commit types such as `feat:` and `fix:` affect versioning and changelog generation. Other types like `build:`, `chore:`, `ci:`, `docs:`, `perf:`, `refactor:`, `revert:`, `style:` and `test:` are valid but will not trigger a release.
+Commit types such as `feat:` and `fix:` affect versioning and changelog generation. Other types like `build:`, `chore:`, `ci:`, `docs:`, `perf:`, `refactor:`, `style:` and `test:` are valid but will not trigger a release.
 
 A commit that has the text `BREAKING CHANGE:` at the beginning of its optional body or footer, or appends a `!` after the type/scope, introduces a breaking API change (correlating with `MAJOR` in semantic versioning).
 
@@ -83,9 +83,9 @@ To test features before publishing a stable release:
 
 2. **Develop on a feature branch** based off `next` and open a PR targeting `next`.
 
-3. **Automatic pre-release:** Each PR merge into `next` triggers CI and publishes a pre-release version (e.g., `1.1.0-next.1`) to the `@next` dist-tag on npm.
+3. **Automatic pre-release:** Each PR merge into `next` triggers CI and publishes a pre-release version (e.g., `1.1.0-next.1`) to the `next` dist-tag on npm.
 
-4. **Promote to stable:** When ready, open a PR to merge `next` into `main`. The PR title must follow Conventional Commits (e.g., `feat: ...`, `fix: ...`) as it determines the version bump for the stable release.
+4. **Promote to stable:** When ready, open a PR to merge `next` into `main`. Use a regular merge commit (not squash), as this preserves the individual commit history and allows semantic-release to correctly generate a comprehensive changelog and determine the version bump automatically.
 
 > **Note:** The `CHANGELOG.md` is only updated for stable releases on `main`. Pre-releases still get GitHub release notes and npm publication.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ Every significant change is documented in the [CHANGELOG.md](CHANGELOG.md) file.
 
 ## Branch Organization
 
-Submit all changes directly to the [main](https://github.com/Doist/outline-cli/tree/main) branch (via PR). We do our best to keep `main` in good shape, with all tests passing.
+Submit all changes to the [main](https://github.com/Doist/outline-cli/tree/main) branch (via PR) by default. For pre-release work, target the `next` branch instead — see [Release Process](#release-process-core-team-only) for details.
 
-For pre-release testing, the `next` branch is used to publish pre-release versions to npm before promoting to stable. See [Release Process](#release-process-core-team-only) for details.
+We do our best to keep `main` in good shape, with all tests passing.
 
 ## Development Workflow
 

--- a/release.config.js
+++ b/release.config.js
@@ -1,20 +1,31 @@
 /**
  * @type {import('semantic-release').GlobalConfig}
  */
+
+const prereleaseBranches = [{ name: 'next', prerelease: true }]
+
+const isPrerelease = prereleaseBranches.some((b) => b.name === process.env.GITHUB_REF_NAME)
+
 export default {
-    branches: ['main'],
+    branches: ['main', ...prereleaseBranches],
     plugins: [
         ['@semantic-release/commit-analyzer', { preset: 'conventionalcommits' }],
         ['@semantic-release/release-notes-generator', { preset: 'conventionalcommits' }],
-        '@semantic-release/changelog',
+        // Only update CHANGELOG.md and commit back on stable releases
+        ...(isPrerelease ? [] : ['@semantic-release/changelog']),
         '@semantic-release/npm',
-        [
-            '@semantic-release/git',
-            {
-                assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
-                message: 'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-            },
-        ],
+        ...(isPrerelease
+            ? []
+            : [
+                  [
+                      '@semantic-release/git',
+                      {
+                          assets: ['CHANGELOG.md', 'package.json', 'package-lock.json'],
+                          message:
+                              'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
+                      },
+                  ],
+              ]),
         '@semantic-release/github',
     ],
 }


### PR DESCRIPTION
## Summary
- Adds `next` branch support to semantic-release config and release workflow
- Merges into `next` will publish pre-release versions to npm under the `next` dist-tag
- Changelog and version commit-back are skipped for pre-releases
- Twist release announcements only fire for stable releases on `main`
- Adds CONTRIBUTING.md with pre-release workflow documentation

## Post-merge setup
After merging, create the `next` branch:
```bash
git checkout -b next main && git push -u origin next
```

## Test plan
- [ ] Verify existing `main` branch releases still work (including Twist announcement)
- [ ] Create `next` branch and merge a `feat:` commit — verify pre-release published with `next` dist-tag
- [ ] Verify Twist announcement does NOT fire for pre-releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)