### PR TITLE
feat: add `ol update` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"test:watch": "vitest",
 		"postinstall": "node scripts/postinstall.js",
 		"check:skill-sync": "node scripts/check-skill-sync.js",
-		"sync:skill": "node scripts/sync-skill.js",
+		"sync:skill": "npm run build && node scripts/sync-skill.js",
 		"prepublishOnly": "npm run build && npm test"
 	},
 	"keywords": [

--- a/skills/outline-cli/SKILL.md
+++ b/skills/outline-cli/SKILL.md
@@ -78,6 +78,14 @@ ol auth status                # Show current auth state
 ol auth logout                # Clear saved credentials
 ```
 
+### Update & Changelog
+```bash
+ol update                     # Update to the latest version
+ol update --check             # Check for updates without installing
+ol changelog                  # Show recent changelog entries
+ol changelog -n 3             # Show last 3 versions
+```
+
 ## Examples
 
 ### Find and read a document

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -1,0 +1,240 @@
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock child_process
+vi.mock('node:child_process', () => ({
+    spawn: vi.fn(),
+}))
+
+// Mock spinner — pass through to the callback
+vi.mock('../lib/spinner.js', () => ({
+    withSpinner: vi.fn((_opts: unknown, fn: () => Promise<unknown>) => fn()),
+}))
+
+import { spawn } from 'node:child_process'
+import { registerUpdateCommand } from '../commands/update.js'
+
+const mockSpawn = vi.mocked(spawn)
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerUpdateCommand(program)
+    return program
+}
+
+function mockFetch(version: string) {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ version }),
+        }),
+    )
+}
+
+function mockFetchError(status: number) {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+            ok: false,
+            status,
+        }),
+    )
+}
+
+function mockFetchNetworkError(message: string) {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error(message)))
+}
+
+function mockSpawnSuccess() {
+    mockSpawn.mockReturnValue({
+        stderr: {
+            on: vi.fn(),
+        },
+        on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+            if (event === 'close') cb(0)
+        }),
+    } as never)
+}
+
+function mockSpawnFailure(exitCode: number) {
+    mockSpawn.mockReturnValue({
+        stderr: {
+            on: vi.fn(),
+        },
+        on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+            if (event === 'close') cb(exitCode)
+        }),
+    } as never)
+}
+
+function mockSpawnPermissionError() {
+    mockSpawn.mockReturnValue({
+        stderr: {
+            on: vi.fn((event: string, cb: (data: Buffer) => void) => {
+                if (event === 'data') cb(Buffer.from('npm ERR! code EACCES\n'))
+            }),
+        },
+        on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+            if (event === 'close') cb(243)
+        }),
+    } as never)
+}
+
+describe('update command', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        process.exitCode = undefined
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        vi.unstubAllGlobals()
+        vi.unstubAllEnvs()
+        process.exitCode = undefined
+    })
+
+    describe('already up to date', () => {
+        it('prints up-to-date message when versions match', async () => {
+            const {
+                default: { version },
+            } = await import('../../package.json')
+            mockFetch(version)
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.stringContaining('Already up to date'),
+            )
+            expect(mockSpawn).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('--check flag', () => {
+        it('shows version info without installing when update available', async () => {
+            mockFetch('99.99.99')
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update', '--check'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Update available'))
+            expect(mockSpawn).not.toHaveBeenCalled()
+        })
+
+        it('shows up-to-date message when already current', async () => {
+            const {
+                default: { version },
+            } = await import('../../package.json')
+            mockFetch(version)
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update', '--check'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.stringContaining('Already up to date'),
+            )
+        })
+    })
+
+    describe('update available', () => {
+        it('spawns npm install and reports success', async () => {
+            mockFetch('99.99.99')
+            mockSpawnSuccess()
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(mockSpawn).toHaveBeenCalledWith(
+                'npm',
+                ['install', '-g', '@doist/outline-cli@latest'],
+                { stdio: 'pipe' },
+            )
+            expect(consoleSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.stringContaining('Updated to v99.99.99'),
+            )
+        })
+
+        it('uses pnpm add when pnpm is detected', async () => {
+            mockFetch('99.99.99')
+            mockSpawnSuccess()
+            vi.stubEnv('npm_execpath', '/usr/local/lib/node_modules/pnpm/bin/pnpm.cjs')
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(mockSpawn).toHaveBeenCalledWith(
+                'pnpm',
+                ['add', '-g', '@doist/outline-cli@latest'],
+                { stdio: 'pipe' },
+            )
+        })
+    })
+
+    describe('registry errors', () => {
+        it('handles HTTP errors from registry', async () => {
+            mockFetchError(503)
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.stringContaining('Failed to check for updates'),
+            )
+            expect(process.exitCode).toBe(1)
+        })
+
+        it('handles network failures', async () => {
+            mockFetchNetworkError('getaddrinfo ENOTFOUND registry.npmjs.org')
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.stringContaining('Failed to check for updates'),
+            )
+            expect(process.exitCode).toBe(1)
+        })
+    })
+
+    describe('install errors', () => {
+        it('suggests sudo on permission error', async () => {
+            mockFetch('99.99.99')
+            mockSpawnPermissionError()
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.stringContaining('Permission denied'),
+            )
+            expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('sudo'))
+            expect(process.exitCode).toBe(1)
+        })
+
+        it('handles non-zero exit code from npm', async () => {
+            mockFetch('99.99.99')
+            mockSpawnFailure(1)
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.stringContaining('exited with code 1'),
+            )
+            expect(process.exitCode).toBe(1)
+        })
+    })
+})

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -11,6 +11,11 @@ vi.mock('../lib/spinner.js', () => ({
     withSpinner: vi.fn((_opts: unknown, fn: () => Promise<unknown>) => fn()),
 }))
 
+// Mock fetchWithRetry to use global fetch (which we stub per-test)
+vi.mock('../transport/fetch-with-retry.js', () => ({
+    fetchWithRetry: vi.fn(({ url }: { url: string }) => fetch(url)),
+}))
+
 import { spawn } from 'node:child_process'
 import { registerUpdateCommand } from '../commands/update.js'
 
@@ -155,7 +160,7 @@ describe('update command', () => {
             expect(mockSpawn).toHaveBeenCalledWith(
                 'npm',
                 ['install', '-g', '@doist/outline-cli@latest'],
-                { stdio: 'pipe' },
+                { stdio: ['ignore', 'ignore', 'pipe'], shell: process.platform === 'win32' },
             )
             expect(consoleSpy).toHaveBeenCalledWith(
                 expect.anything(),
@@ -174,7 +179,7 @@ describe('update command', () => {
             expect(mockSpawn).toHaveBeenCalledWith(
                 'pnpm',
                 ['add', '-g', '@doist/outline-cli@latest'],
-                { stdio: 'pipe' },
+                { stdio: ['ignore', 'ignore', 'pipe'], shell: process.platform === 'win32' },
             )
         })
     })

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,0 +1,120 @@
+import { spawn } from 'node:child_process'
+import chalk from 'chalk'
+import { Command } from 'commander'
+import packageJson from '../../package.json' with { type: 'json' }
+import { withSpinner } from '../lib/spinner.js'
+
+const PACKAGE_NAME = '@doist/outline-cli'
+const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`
+
+interface RegistryResponse {
+    version: string
+}
+
+async function fetchLatestVersion(): Promise<string> {
+    const response = await fetch(REGISTRY_URL)
+    if (!response.ok) {
+        throw new Error(`Registry request failed (HTTP ${response.status})`)
+    }
+    const data = (await response.json()) as RegistryResponse
+    return data.version
+}
+
+function detectPackageManager(): string {
+    const execPath = process.env.npm_execpath || process.argv[1] || ''
+    if (execPath.includes('pnpm')) return 'pnpm'
+    return 'npm'
+}
+
+function runInstall(pm: string): Promise<{ exitCode: number; stderr: string }> {
+    const command = pm === 'pnpm' ? 'add' : 'install'
+    return new Promise((resolve, reject) => {
+        const child = spawn(pm, [command, '-g', `${PACKAGE_NAME}@latest`], {
+            stdio: 'pipe',
+        })
+
+        let stderr = ''
+        child.stderr?.on('data', (data: Buffer) => {
+            stderr += data.toString()
+        })
+
+        child.on('error', reject)
+        child.on('close', (code) => resolve({ exitCode: code ?? 1, stderr }))
+    })
+}
+
+export async function updateAction(options: { check?: boolean }): Promise<void> {
+    const currentVersion = packageJson.version
+
+    let latestVersion: string
+    try {
+        latestVersion = await withSpinner(
+            { text: 'Checking for updates...', color: 'blue' },
+            fetchLatestVersion,
+        )
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        console.error(chalk.red('Error:'), `Failed to check for updates: ${message}`)
+        process.exitCode = 1
+        return
+    }
+
+    if (currentVersion === latestVersion) {
+        console.log(chalk.green('✓'), `Already up to date (v${currentVersion})`)
+        return
+    }
+
+    console.log(
+        `Update available: ${chalk.dim(`v${currentVersion}`)} → ${chalk.green(`v${latestVersion}`)}`,
+    )
+
+    if (options.check) {
+        return
+    }
+
+    const pm = detectPackageManager()
+
+    let result: { exitCode: number; stderr: string }
+    try {
+        result = await withSpinner(
+            { text: `Updating to v${latestVersion}...`, color: 'blue' },
+            () => runInstall(pm),
+        )
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        console.error(chalk.red('Error:'), `Install failed: ${message}`)
+        process.exitCode = 1
+        return
+    }
+
+    if (result.exitCode !== 0) {
+        if (
+            result.stderr &&
+            (result.stderr.includes('EACCES') || result.stderr.includes('EPERM'))
+        ) {
+            console.error(chalk.red('Error:'), 'Permission denied. Try running with sudo:')
+            console.error(
+                chalk.dim(
+                    `  sudo ${pm} ${pm === 'pnpm' ? 'add' : 'install'} -g ${PACKAGE_NAME}@latest`,
+                ),
+            )
+        } else {
+            console.error(chalk.red('Error:'), `${pm} exited with code ${result.exitCode}`)
+            if (result.stderr) {
+                console.error(chalk.dim(result.stderr.trim()))
+            }
+        }
+        process.exitCode = 1
+        return
+    }
+
+    console.log(chalk.green('✓'), `Updated to v${latestVersion}`)
+}
+
+export function registerUpdateCommand(program: Command): void {
+    program
+        .command('update')
+        .description('Update the CLI to the latest version')
+        .option('--check', 'Check for updates without installing')
+        .action(updateAction)
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import packageJson from '../../package.json' with { type: 'json' }
 import { withSpinner } from '../lib/spinner.js'
+import { fetchWithRetry } from '../transport/fetch-with-retry.js'
 
 const PACKAGE_NAME = '@doist/outline-cli'
 const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`
@@ -12,7 +13,7 @@ interface RegistryResponse {
 }
 
 async function fetchLatestVersion(): Promise<string> {
-    const response = await fetch(REGISTRY_URL)
+    const response = await fetchWithRetry({ url: REGISTRY_URL })
     if (!response.ok) {
         throw new Error(`Registry request failed (HTTP ${response.status})`)
     }
@@ -30,7 +31,8 @@ function runInstall(pm: string): Promise<{ exitCode: number; stderr: string }> {
     const command = pm === 'pnpm' ? 'add' : 'install'
     return new Promise((resolve, reject) => {
         const child = spawn(pm, [command, '-g', `${PACKAGE_NAME}@latest`], {
-            stdio: 'pipe',
+            stdio: ['ignore', 'ignore', 'pipe'],
+            shell: process.platform === 'win32',
         })
 
         let stderr = ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { registerCollectionCommand } from './commands/collection.js'
 import { registerDocumentCommand } from './commands/document.js'
 import { registerSearchCommand } from './commands/search.js'
 import { registerSkillCommand } from './commands/skill.js'
+import { registerUpdateCommand } from './commands/update.js'
 
 const program = new Command()
 
@@ -26,6 +27,7 @@ registerSearchCommand(program)
 registerDocumentCommand(program)
 registerCollectionCommand(program)
 registerSkillCommand(program)
+registerUpdateCommand(program)
 
 program.parseAsync().catch((err: Error) => {
     console.error(err.message)

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -77,6 +77,14 @@ ol auth status                # Show current auth state
 ol auth logout                # Clear saved credentials
 \`\`\`
 
+### Update & Changelog
+\`\`\`bash
+ol update                     # Update to the latest version
+ol update --check             # Check for updates without installing
+ol changelog                  # Show recent changelog entries
+ol changelog -n 3             # Show last 3 versions
+\`\`\`
+
 ## Examples
 
 ### Find and read a document


### PR DESCRIPTION
## Summary
- Adds an `ol update` command that checks the npm registry and self-updates the CLI
- Shows old → new version, hides npm output, displays spinner during update
- Supports `--check` flag (check without installing), pnpm detection, and permission error handling with sudo suggestion

## Test plan
- [x] `npm run build` passes
- [x] `npm run type-check` passes
- [x] `npm run lint:check` / `npm run format:check` passes
- [x] All 103 tests pass (9 new update command tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)