### PR TITLE
feat: add `ol changelog` command

### DIFF
--- a/src/__tests__/changelog.test.ts
+++ b/src/__tests__/changelog.test.ts
@@ -1,0 +1,161 @@
+import { Command } from 'commander'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:fs/promises')
+
+import { readFile } from 'node:fs/promises'
+import { registerChangelogCommand } from '../commands/changelog.js'
+
+const mockReadFile = vi.mocked(readFile)
+
+const SAMPLE_CHANGELOG = `# Changelog
+
+## [1.5.0](https://example.com) (2026-03-15)
+
+### Features
+
+* feature five
+
+## [1.4.0](https://example.com) (2026-03-14)
+
+### Features
+
+* feature four
+
+## [1.3.0](https://example.com) (2026-03-13)
+
+### Bug Fixes
+
+* fix three
+
+## [1.2.0](https://example.com) (2026-03-12)
+
+### Features
+
+* feature two
+
+## [1.1.0](https://example.com) (2026-03-11)
+
+### Features
+
+* feature one
+
+## [1.0.0](https://example.com) (2026-03-10)
+
+### Features
+
+* initial release
+`
+
+function createProgram() {
+    const program = new Command()
+    program.exitOverride()
+    registerChangelogCommand(program)
+    return program
+}
+
+describe('changelog command', () => {
+    let consoleSpy: ReturnType<typeof vi.spyOn>
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        process.exitCode = undefined
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        process.exitCode = undefined
+    })
+
+    it('shows last 5 versions by default', async () => {
+        mockReadFile.mockResolvedValue(SAMPLE_CHANGELOG)
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'ol', 'changelog'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('1.5.0'))
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('1.1.0'))
+        // Should show "view full changelog" link since there are 6 versions
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('View full changelog'))
+    })
+
+    it('includes latest version when changelog has no preamble', async () => {
+        const noPreambleChangelog = `## [2.0.0](https://example.com) (2026-03-20)
+
+### Features
+
+* new major version
+
+## [1.5.0](https://example.com) (2026-03-15)
+
+### Features
+
+* feature five
+`
+        mockReadFile.mockResolvedValue(noPreambleChangelog)
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'ol', 'changelog'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(output).toContain('2.0.0')
+        expect(output).toContain('1.5.0')
+    })
+
+    it('respects --count option', async () => {
+        mockReadFile.mockResolvedValue(SAMPLE_CHANGELOG)
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'ol', 'changelog', '-n', '2'])
+
+        const output = consoleSpy.mock.calls[0][0] as string
+        expect(output).toContain('1.5.0')
+        expect(output).toContain('1.4.0')
+        expect(output).not.toContain('1.3.0')
+    })
+
+    it('handles fewer entries than requested', async () => {
+        const shortChangelog = `# Changelog
+
+## [1.1.0](https://example.com) (2026-03-11)
+
+### Features
+
+* only version
+`
+        mockReadFile.mockResolvedValue(shortChangelog)
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'ol', 'changelog'])
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('1.1.0'))
+        // Should NOT show "view full changelog" link since all versions are shown
+        expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('View full changelog'))
+    })
+
+    it('handles missing changelog file', async () => {
+        mockReadFile.mockRejectedValue(new Error('ENOENT'))
+
+        const program = createProgram()
+        await program.parseAsync(['node', 'ol', 'changelog'])
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.stringContaining('Could not read changelog file'),
+        )
+        expect(process.exitCode).toBe(1)
+    })
+
+    it('handles invalid count', async () => {
+        const program = createProgram()
+        await program.parseAsync(['node', 'ol', 'changelog', '-n', 'abc'])
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.stringContaining('Count must be a positive number'),
+        )
+        expect(process.exitCode).toBe(1)
+    })
+})

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -55,13 +55,13 @@ function cleanChangelog(text: string): string {
             // Clean up blank lines left by removed dep lines
             .replace(/\n{3,}/g, '\n\n')
             // Remove section headers left empty after filtering (e.g. ### Bug Fixes with no items)
-            .replace(/### [\w ]+\n\n(?=##|$)/gm, '')
+            .replace(/### [\w ]+\n\n(?=#|$)/gm, '')
     )
 }
 
 function parseChangelog(content: string, count: number): { text: string; hasMore: boolean } {
-    const sections = content.split(/\n(?=## \[)/)
-    const versionSections = sections.filter((s) => s.startsWith('## ['))
+    const sections = content.split(/\n(?=## (?:\d|\[))/)
+    const versionSections = sections.filter((s) => /^## (?:\d|\[)/.test(s))
     const selected = versionSections.slice(0, count)
 
     if (selected.length === 0) {
@@ -79,8 +79,8 @@ interface ChangelogOptions {
 }
 
 export async function changelogAction(options: ChangelogOptions): Promise<void> {
-    const count = parseInt(options.count, 10)
-    if (isNaN(count) || count < 1) {
+    const count = Number(options.count)
+    if (!Number.isInteger(count) || count < 1) {
         console.error(chalk.red('Error:'), 'Count must be a positive number')
         process.exitCode = 1
         return

--- a/src/commands/changelog.ts
+++ b/src/commands/changelog.ts
@@ -1,0 +1,112 @@
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import chalk from 'chalk'
+import { Command } from 'commander'
+import packageJson from '../../package.json' with { type: 'json' }
+
+const CHANGELOG_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'CHANGELOG.md')
+const CHANGELOG_URL = `https://github.com/Doist/outline-cli/blob/v${packageJson.version}/CHANGELOG.md`
+
+function formatInline(text: string): string {
+    return text
+        .replace(/\*\*([^*]+)\*\*/g, (_, content) => chalk.bold(content))
+        .replace(/`([^`]+)`/g, (_, code) => chalk.cyan(code))
+}
+
+function formatForTerminal(text: string): string {
+    return text
+        .split('\n')
+        .map((line) => {
+            // Version headers: ## 1.25.0 (date) → bold green
+            if (line.startsWith('## ')) {
+                return chalk.green.bold(line.slice(3))
+            }
+            // Section headers: ### Features → bold
+            if (line.startsWith('### ')) {
+                return chalk.bold(line.slice(4))
+            }
+            // Bullet items: * or - description → dimmed bullet + text
+            if (line.startsWith('* ')) {
+                return `  ${chalk.dim('•')} ${formatInline(line.slice(2))}`
+            }
+            if (line.startsWith('- ')) {
+                return `  ${chalk.dim('•')} ${formatInline(line.slice(2))}`
+            }
+            return formatInline(line)
+        })
+        .join('\n')
+}
+
+function cleanChangelog(text: string): string {
+    return (
+        text
+            // Version headers: ## [1.25.0](https://...) (date) → ## 1.25.0 (date)
+            .replace(/## \[([^\]]+)\]\([^)]*\)/g, '## $1')
+            // Remove commit hash links: ([abc1234](https://...))
+            .replace(/ \([a-f0-9]{7}\)/g, '')
+            .replace(/ \(\[[a-f0-9]{7}\]\([^)]*\)\)/g, '')
+            // Issue/PR links: [#151](https://...) → #151
+            .replace(/\[#(\d+)\]\([^)]*\)/g, '#$1')
+            // Remove **deps:** dependency update lines (not useful to end users)
+            .replace(/^[*-] \*\*deps:\*\*.*$/gm, '')
+            // Remove **scope:** prefixes but keep the text: **task:** foo → foo
+            .replace(/\*\*[\w-]+:\*\* /g, '')
+            // Clean up blank lines left by removed dep lines
+            .replace(/\n{3,}/g, '\n\n')
+            // Remove section headers left empty after filtering (e.g. ### Bug Fixes with no items)
+            .replace(/### [\w ]+\n\n(?=##|$)/gm, '')
+    )
+}
+
+function parseChangelog(content: string, count: number): { text: string; hasMore: boolean } {
+    const sections = content.split(/\n(?=## \[)/)
+    const versionSections = sections.filter((s) => s.startsWith('## ['))
+    const selected = versionSections.slice(0, count)
+
+    if (selected.length === 0) {
+        return { text: 'No changelog entries found.', hasMore: false }
+    }
+
+    return {
+        text: cleanChangelog(selected.join('\n').trimEnd()),
+        hasMore: versionSections.length > count,
+    }
+}
+
+interface ChangelogOptions {
+    count: string
+}
+
+export async function changelogAction(options: ChangelogOptions): Promise<void> {
+    const count = parseInt(options.count, 10)
+    if (isNaN(count) || count < 1) {
+        console.error(chalk.red('Error:'), 'Count must be a positive number')
+        process.exitCode = 1
+        return
+    }
+
+    let content: string
+    try {
+        content = await readFile(CHANGELOG_PATH, 'utf-8')
+    } catch {
+        console.error(chalk.red('Error:'), 'Could not read changelog file')
+        process.exitCode = 1
+        return
+    }
+
+    const { text, hasMore } = parseChangelog(content, count)
+    console.log(formatForTerminal(text))
+
+    if (hasMore) {
+        console.log(chalk.dim(`\nView full changelog: ${CHANGELOG_URL}`))
+    }
+}
+
+export function registerChangelogCommand(program: Command): void {
+    program
+        .command('changelog')
+        .description('Show recent changelog entries')
+        .option('-n, --count <number>', 'Number of versions to show', '5')
+        .action(changelogAction)
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -111,6 +111,7 @@ export async function updateAction(options: { check?: boolean }): Promise<void> 
     }
 
     console.log(chalk.green('✓'), `Updated to v${latestVersion}`)
+    console.log(chalk.dim('  Run'), chalk.cyan('ol changelog'), chalk.dim('to see what changed'))
 }
 
 export function registerUpdateCommand(program: Command): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 import { registerAuthCommand } from './commands/auth.js'
+import { registerChangelogCommand } from './commands/changelog.js'
 import { registerCollectionCommand } from './commands/collection.js'
 import { registerDocumentCommand } from './commands/document.js'
 import { registerSearchCommand } from './commands/search.js'
@@ -27,6 +28,7 @@ registerSearchCommand(program)
 registerDocumentCommand(program)
 registerCollectionCommand(program)
 registerSkillCommand(program)
+registerChangelogCommand(program)
 registerUpdateCommand(program)
 
 program.parseAsync().catch((err: Error) => {


### PR DESCRIPTION
## Summary
- Adds an `ol changelog` command that reads the bundled CHANGELOG.md, cleans up markdown links/hashes, and renders formatted output to the terminal
- Supports `-n` / `--count` option to control how many versions to show (default 5)
- Adds `ol changelog` hint to the update command's success output

## Test plan
- [x] `npm run build` passes
- [x] `npm run type-check` passes
- [x] `npm run lint:check` / `npm run format:check` passes
- [x] All 109 tests pass (6 new changelog command tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)