### PR TITLE
fix: secure config permissions and address update channel review feedback

### DIFF
--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -347,10 +347,7 @@ describe('update command', () => {
             const program = createProgram()
             await program.parseAsync(['node', 'ol', 'update'])
 
-            expect(consoleSpy).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.stringContaining('older than your current'),
-            )
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Downgrade available'))
             expect(mockSpawn).toHaveBeenCalledWith(
                 'npm',
                 ['install', '-g', '@doist/outline-cli@next'],

--- a/src/__tests__/update.test.ts
+++ b/src/__tests__/update.test.ts
@@ -329,6 +329,17 @@ describe('update command', () => {
             expect(mockSpawn).not.toHaveBeenCalled()
         })
 
+        it('treats next.10 as newer than next.2 (multi-digit prerelease)', async () => {
+            mockFetch('1.6.0-next.10')
+            mockSpawnSuccess()
+
+            const program = createProgram()
+            await program.parseAsync(['node', 'ol', 'update'])
+
+            expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Update available'))
+            expect(mockSpawn).toHaveBeenCalled()
+        })
+
         it('warns but still installs when channel tag resolves to older version', async () => {
             mockFetch('1.4.0-next.1')
             mockSpawnSuccess()

--- a/src/commands/update/action.ts
+++ b/src/commands/update/action.ts
@@ -141,8 +141,7 @@ export async function updateAction(options: { check?: boolean }): Promise<void> 
         )
     } else {
         console.log(
-            chalk.yellow('Note:'),
-            `v${latestVersion}${label} is older than your current v${currentVersion}`,
+            `Downgrade available${label}: ${chalk.dim(`v${currentVersion}`)} → ${chalk.yellow(`v${latestVersion}`)}`,
         )
     }
 

--- a/src/commands/update/action.ts
+++ b/src/commands/update/action.ts
@@ -115,12 +115,16 @@ export async function updateAction(options: { check?: boolean }): Promise<void> 
                 ? `  Channel: ${chalk.magenta('pre-release')}`
                 : `  Channel: ${chalk.green('stable')}`
 
-        if (updateAvailable) {
+        if (currentVersion === latestVersion) {
+            console.log(chalk.green('✓'), `Already up to date (v${currentVersion})`)
+        } else if (updateAvailable) {
             console.log(
                 `Update available: ${chalk.dim(`v${currentVersion}`)} → ${chalk.green(`v${latestVersion}`)}`,
             )
         } else {
-            console.log(chalk.green('✓'), `Already up to date (v${currentVersion})`)
+            console.log(
+                `Downgrade available: ${chalk.dim(`v${currentVersion}`)} → ${chalk.yellow(`v${latestVersion}`)}`,
+            )
         }
         console.log(channelLine)
         return

--- a/src/lib/update-config.ts
+++ b/src/lib/update-config.ts
@@ -32,6 +32,9 @@ export function setUpdateChannel(channel: UpdateChannel): void {
         }
     }
     existing.update_channel = channel
-    mkdirSync(CONFIG_DIR, { recursive: true })
-    writeFileSync(CONFIG_PATH, `${JSON.stringify(existing, null, 2)}\n`)
+    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
+    writeFileSync(CONFIG_PATH, `${JSON.stringify(existing, null, 2)}\n`, {
+        encoding: 'utf-8',
+        mode: 0o600,
+    })
 }

--- a/src/lib/update-config.ts
+++ b/src/lib/update-config.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -37,4 +37,5 @@ export function setUpdateChannel(channel: UpdateChannel): void {
         encoding: 'utf-8',
         mode: 0o600,
     })
+    chmodSync(CONFIG_PATH, 0o600)
 }


### PR DESCRIPTION
## Summary

- **Secure file permissions**: `setUpdateChannel` now creates the config directory with `0o700` and writes `config.json` with `0o600` to prevent other users from reading sensitive config
- **`--check` downgrade display**: The `--check` path now has a proper three-way branch distinguishing "up to date", "update available", and "downgrade available" (previously a downgrade showed as "up to date")

Note: The prerelease `localeCompare` fix and `process.argv[1]` fallback were already present in the merged code, so no changes were needed for those.

## Test plan

- [x] `npm run type-check` passes
- [x] All 122 tests pass (`npm test`)
- [x] `npm run lint:check` passes (0 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)