### PR TITLE
ci: pin semantic PR action to reviewed SHA

### DIFF
--- a/.github/workflows/check-semantic-pull-request.yml
+++ b/.github/workflows/check-semantic-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Validate PR title
-              uses: amannn/action-semantic-pull-request@v5
+              uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               with:


### PR DESCRIPTION
Pins `amannn/action-semantic-pull-request` in the semantic PR workflow to the audited SHA already present in Doist's allowlist.

This removes the floating `@v5` reference flagged in #46.

Tests: `npm test`

Closes #46.