### PR TITLE
fix: opt out of response compression to avoid Node 24+ fetch gzip bug

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -29,6 +29,7 @@ describe("apiRequest", () => {
 			{
 				method: "POST",
 				headers: {
+					"Accept-Encoding": "identity",
 					"Content-Type": "application/json",
 					Authorization: "Bearer test-token",
 				},

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -56,9 +56,14 @@ async function rawApiRequest<T>(
 	const baseUrl = getBaseUrl();
 	const token = getApiToken();
 
+	// `Accept-Encoding: identity` opts out of response compression. On Node 24+,
+	// global `fetch` can return raw gzipped bytes that fail `res.json()` parsing
+	// ("Unexpected token '...' is not valid JSON"). Asking the server for an
+	// uncompressed payload sidesteps the issue across Node versions.
 	const res = await fetch(`${baseUrl}/api/${path}`, {
 		method: "POST",
 		headers: {
+			"Accept-Encoding": "identity",
 			"Content-Type": "application/json",
 			Authorization: `Bearer ${token}`,
 		},


### PR DESCRIPTION
## Summary

- Fix `ol auth status` (and the OAuth login flow's `auth.info` step) failing on Node 24+ with `Unexpected token '...' is not valid JSON` — `res.json()` was choking on raw gzipped response bytes.
- Send `Accept-Encoding: identity` on every API request so the server returns an uncompressed payload, sidestepping whatever decompression path Node mishandles.

## Background

Same family of bug as [`Doist/twist-sdk-typescript#126`](https://github.com/Doist/twist-sdk-typescript/pull/126). That PR framed it as "only with a custom undici dispatcher", but `ol` reproduces the symptom on Node 26 against `handbook.doist.com` using bare `fetch` with no custom dispatcher. The smallest robust fix is the same one the SDK landed on: opt out of response compression entirely. Cost is uncompressed JSON, negligible for this CLI's small payloads.

## Test plan

- [x] `npm run type-check`
- [x] `npm test` — 77/77 passing (api.test.ts header assertion updated)
- [x] `npm run build && node dist/index.js auth status` against `handbook.doist.com` on Node 26 — prints team/user (was failing pre-fix)
- [x] `ol auth login --token <token>` end-to-end on Node 26 (token-flow exercises the same `apiRequest` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)