### PR TITLE
refactor: Start integrating `@doist/cli-core`

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"7984e939-7b46-44e1-b779-2cfcc5126369","pid":745646,"procStart":"20830249","acquiredAt":1778507604843}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7984e939-7b46-44e1-b779-2cfcc5126369","pid":745646,"procStart":"20830249","acquiredAt":1778507604843}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
+				"@doist/cli-core": "0.9.0",
 				"chalk": "5.6.2",
 				"commander": "14.0.2",
-				"marked": "15.0.12",
-				"marked-terminal": "7.3.0",
+				"marked": "18.0.3",
+				"marked-terminal-renderer": "2.2.0",
 				"open": "10.2.0",
-				"undici": "7.22.0",
-				"yocto-spinner": "1.0.0"
+				"undici": "7.22.0"
 			},
 			"bin": {
 				"ol": "dist/index.js"
@@ -31,7 +31,7 @@
 				"oxlint": "1.57.0",
 				"semantic-release": "25.0.3",
 				"typescript": "5.9.3",
-				"vitest": "4.0.18"
+				"vitest": "4.1.5"
 			},
 			"engines": {
 				"node": ">=20.18.1"
@@ -111,6 +111,16 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/@colors/colors": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -121,444 +131,497 @@
 				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-			"integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
-			"cpu": [
-				"ppc64"
-			],
+		"node_modules/@doist/cli-core": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@doist/cli-core/-/cli-core-0.9.0.tgz",
+			"integrity": "sha512-38uTt+DSFCMuuPkdWIl9Dm7XrjGlwG15eI0DrnaKEYm+AGizzP6tY7m1AZAT5aQXAJOCU6uYXAvqaqpni+PcLg==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "5.6.2",
+				"yocto-spinner": "1.1.0"
+			},
+			"engines": {
+				"node": ">=20.18.1"
+			},
+			"peerDependencies": {
+				"commander": ">=14",
+				"marked": ">=18",
+				"marked-terminal-renderer": ">=2",
+				"open": ">=10",
+				"vitest": ">=4.1"
+			},
+			"peerDependenciesMeta": {
+				"commander": {
+					"optional": true
+				},
+				"marked": {
+					"optional": true
+				},
+				"marked-terminal-renderer": {
+					"optional": true
+				},
+				"open": {
+					"optional": true
+				},
+				"vitest": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"os": [
-				"aix"
-			],
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/wasi-threads": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@jimp/core": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/core/-/core-1.6.1.tgz",
+			"integrity": "sha512-+BoKC5G6hkrSy501zcJ2EpfnllP+avPevcBfRcZe/CW+EwEfY6X1EZ8QWyT7NpDIvEEJb1fdJnMMfUnFkxmw9A==",
+			"license": "MIT",
+			"dependencies": {
+				"@jimp/file-ops": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"await-to-js": "^3.0.0",
+				"exif-parser": "^0.1.12",
+				"file-type": "^21.3.3",
+				"mime": "3"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-			"integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
+		"node_modules/@jimp/core/node_modules/mime": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@jimp/diff": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/diff/-/diff-1.6.1.tgz",
+			"integrity": "sha512-YkKDPdHjLgo1Api3+Bhc0GLAygldlpt97NfOKoNg1U6IUNXA6X2MgosCjPfSBiSvJvrrz1fsIR+/4cfYXBI/HQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jimp/plugin-resize": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"pixelmatch": "^5.3.0"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-			"integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/file-ops": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/file-ops/-/file-ops-1.6.1.tgz",
+			"integrity": "sha512-T+gX6osHjprbDRad0/B71Evyre7ZdVY1z/gFGEG9Z8KOtZPKboWvPeP2UjbZYWQLy9UKCPQX1FNAnDiOPkJL7w==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-			"integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/js-bmp": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/js-bmp/-/js-bmp-1.6.1.tgz",
+			"integrity": "sha512-xzWzNT4/u5zGrTT3Tme9sGU7YzIKxi13+BCQwLqACbt5DXf9SAfdzRkopZQnmDko+6In5nqaT89Gjs43/WdnYQ==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"bmp-ts": "^1.0.9"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-			"integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/js-gif": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/js-gif/-/js-gif-1.6.1.tgz",
+			"integrity": "sha512-YjY2W26rQa05XhanYhRZ7dingCiNN+T2Ymb1JiigIbABY0B28wHE3v3Cf1/HZPWGu0hOg36ylaKgV5KxF2M58w==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"gifwrap": "^0.10.1",
+				"omggif": "^1.0.10"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-			"integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/js-jpeg": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/js-jpeg/-/js-jpeg-1.6.1.tgz",
+			"integrity": "sha512-HT9H3yOmlOFzYmdI15IYdfy6ggQhSRIaHeA+OTJSEORXBqEo97sUZu/DsgHIcX5NJ7TkJBTgZ9BZXsV6UbsyMg==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"jpeg-js": "^0.4.4"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-			"integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/js-png": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/js-png/-/js-png-1.6.1.tgz",
+			"integrity": "sha512-SZ/KVhI5UjcSzzlXsXdIi/LhJ7UShf2NkMOtVrbZQcGzsqNtynAelrOXeoTxcanfVqmNhAoVHg8yR2cYoqrYjA==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"pngjs": "^7.0.0"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-			"integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/js-tiff": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/js-tiff/-/js-tiff-1.6.1.tgz",
+			"integrity": "sha512-jDG/eJquID1M4MBlKMmDRBmz2TpXMv7TUyu2nIRUxhlUc2ogC82T+VQUkca9GJH1BBJ9dx5sSE5dGkWNjIbZxw==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"utif2": "^4.1.0"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-			"integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-blit": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-1.6.1.tgz",
+			"integrity": "sha512-MwnI7C7K81uWddY9FLw1fCOIy6SsPIUftUz36Spt7jisCn8/40DhQMlSxpxTNelnZb/2SnloFimQfRZAmHLOqQ==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-			"integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-blur": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-1.6.1.tgz",
+			"integrity": "sha512-lIo7Tzp5jQu30EFFSK/phXANK3citKVEjepDjQ6ljHoIFtuMRrnybnmI2Md24ulvWlDaz+hh3n6qrMb8ydwhZQ==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/utils": "1.6.1"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-			"integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-circle": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-1.6.1.tgz",
+			"integrity": "sha512-kK1PavY6cKHNNKce37vdV4Tmpc1/zDKngGoeOV3j+EMatoHFZUinV3s6F9aWryPs3A0xhCLZgdJ6Zeea1d5LCQ==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/types": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-			"integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-color": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-1.6.1.tgz",
+			"integrity": "sha512-LtUN1vAP+LRlZAtTNVhDRSiXx+26Kbz3zJaG6a5k59gQ95jgT5mknnF8lxkHcqJthM4MEk3/tPxkdJpEybyF/A==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"tinycolor2": "^1.6.0",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-			"integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-contain": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-1.6.1.tgz",
+			"integrity": "sha512-m0qhrfA8jkTqretGv4w+T/ADFR4GwBpE0sCOC2uJ0dzr44/ddOMsIdrpi89kabqYiPYIrxkgdCVCLm3zn1Vkkg==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/plugin-blit": "1.6.1",
+				"@jimp/plugin-resize": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-			"integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-cover": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-1.6.1.tgz",
+			"integrity": "sha512-hZytnsth0zoll6cPf434BrT+p/v569Wr5tyO6Dp0dH1IDPhzhB5F38sZGMLDo7bzQiN9JFVB3fxkcJ/WYCJ3Mg==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/plugin-crop": "1.6.1",
+				"@jimp/plugin-resize": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-			"integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-crop": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-1.6.1.tgz",
+			"integrity": "sha512-EerRSLlclXyKDnYc/H9w/1amZW7b7v3OGi/VlerPd2M/pAu5X8TkyYWtfqYCXnNp1Ixtd8oCo9zGfY9zoXT4rg==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-			"integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-displace": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-1.6.1.tgz",
+			"integrity": "sha512-K07QVl7xQwIfD6KfxRV/c3E9e7ZBXxUXdWuvoTWcKHL2qV48MOF5Nqbz/aJW4ThnQARIsxvYlZjPFiqkCjlU+g==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-			"integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-dither": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-1.6.1.tgz",
+			"integrity": "sha512-+2V+GCV2WycMoX1/z977TkZ8Zq/4MVSKElHYatgUqtwXMi2fDK2gKYU2g9V39IqFvTJsTIsK0+58VFz/ROBVew==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
+			"dependencies": {
+				"@jimp/types": "1.6.1"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-			"integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-fisheye": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-1.6.1.tgz",
+			"integrity": "sha512-XtS5ZyoZ0vxZxJ6gkqI63SivhtI58vX95foMPM+cyzYkRsJXMOYCr8DScxF5bp4Xr003NjYm/P+7+08tibwzHA==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
+			"dependencies": {
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-			"integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-flip": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-1.6.1.tgz",
+			"integrity": "sha512-ws38W/sGj7LobNRayQ83garxiktOyWxM5vO/y4a/2cy9v65SLEUzVkrj+oeAaUSSObdz4HcCEla7XtGlnAGAaA==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
+			"dependencies": {
+				"@jimp/types": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-			"integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-hash": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-hash/-/plugin-hash-1.6.1.tgz",
+			"integrity": "sha512-sZt6ZcMX6i8vFWb4GYnw0pR/o9++ef0dTVcboTB5B/g7nrxCODIB4wfEkJ/YqZM5wUvol77K1qeS0/rVO6z21A==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/js-bmp": "1.6.1",
+				"@jimp/js-jpeg": "1.6.1",
+				"@jimp/js-png": "1.6.1",
+				"@jimp/js-tiff": "1.6.1",
+				"@jimp/plugin-color": "1.6.1",
+				"@jimp/plugin-resize": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"any-base": "^1.1.0"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-			"integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-mask": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-1.6.1.tgz",
+			"integrity": "sha512-SIG0/FcmEj3tkwFxc7fAGLO8o4uNzMpSOdQOhbCgxefQKq5wOVMk9BQx/sdMPBwtMLr9WLq0GzLA/rk6t2v20A==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
+			"dependencies": {
+				"@jimp/types": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-			"integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-print": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-1.6.1.tgz",
+			"integrity": "sha512-BYVz/X3Xzv8XYilVeDy11NOp0h7BTDjlOtu0BekIFHP1yHVd24AXNzbOy52XlzYZWQ0Dl36HOHEpl/nSNrzc6w==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/js-jpeg": "1.6.1",
+				"@jimp/js-png": "1.6.1",
+				"@jimp/plugin-blit": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"parse-bmfont-ascii": "^1.0.6",
+				"parse-bmfont-binary": "^1.0.6",
+				"parse-bmfont-xml": "^1.1.6",
+				"simple-xml-to-json": "^1.2.2",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-			"integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-quantize": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-quantize/-/plugin-quantize-1.6.1.tgz",
+			"integrity": "sha512-J2En9PLURfP+vwYDtuZ9T8yBW6BWYZBScydAjRiPBmJfEhTcNQqiiQODrZf7EqbbX/Sy5H6dAeRiqkgoV9N6Ww==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
+			"dependencies": {
+				"image-q": "^4.0.0",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-			"integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-resize": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-1.6.1.tgz",
+			"integrity": "sha512-CLkrtJoIz2HdWnpYiN6p8KYcPc00rCH/SUu6o+lfZL05Q4uhecJlnvXuj9x+U6mDn3ldPmJj6aZqMHuUJzdVqg==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-			"integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-rotate": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-1.6.1.tgz",
+			"integrity": "sha512-nOjVjbbj705B02ksysKnh0POAwEBXZtJ9zQ5qC+X7Tavl3JNn+P3BzQovbBxLPSbUSld6XID9z5ijin4PtOAUg==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/plugin-crop": "1.6.1",
+				"@jimp/plugin-resize": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"zod": "^3.23.8"
+			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-			"integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
+		"node_modules/@jimp/plugin-threshold": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-1.6.1.tgz",
+			"integrity": "sha512-JOKv9F8s6tnVLf4sB/2fF0F339EFnHvgEdFYugO6VhowKLsap0pEZmLyE/DlRnYtIj2RddHZVxVMp/eKJ04l2Q==",
 			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/plugin-color": "1.6.1",
+				"@jimp/plugin-hash": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1",
+				"zod": "^3.23.8"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@jimp/types": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/types/-/types-1.6.1.tgz",
+			"integrity": "sha512-leI7YbveTNi565m910XgIOwXyuu074H5qazAD1357HImJSv2hqxnWXpwxQbadGWZ7goZRYBDZy5lpqud0p7q5w==",
+			"license": "MIT",
+			"dependencies": {
+				"zod": "^3.23.8"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@jimp/utils": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-1.6.1.tgz",
+			"integrity": "sha512-veFPRd93FCnS7AgmCkPgARVGoDRrJ9cm1ujuNyA+UfQ5VKbED2002sm5XfFLFwTsKC8j04heTrwe+tU1dluXOw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jimp/types": "1.6.1",
+				"tinycolor2": "^1.6.0"
+			},
 			"engines": {
 				"node": ">=18"
 			}
@@ -567,8 +630,33 @@
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/@keyv/serialize": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+			"license": "MIT"
+		},
+		"node_modules/@napi-rs/wasm-runtime": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tybys/wasm-util": "^0.10.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Brooooooklyn"
+			},
+			"peerDependencies": {
+				"@emnapi/core": "^1.7.1",
+				"@emnapi/runtime": "^1.7.1"
+			}
 		},
 		"node_modules/@octokit/auth-token": {
 			"version": "6.0.0",
@@ -725,6 +813,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^27.0.0"
+			}
+		},
+		"node_modules/@oxc-project/types": {
+			"version": "0.129.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+			"integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+			"devOptional": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
 		"node_modules/@oxfmt/binding-android-arm-eabi": {
@@ -1418,24 +1516,10 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-			"integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-			"integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+		"node_modules/@rolldown/binding-android-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+			"integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1444,12 +1528,15 @@
 			"optional": true,
 			"os": [
 				"android"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-			"integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+		"node_modules/@rolldown/binding-darwin-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+			"integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
 			"cpu": [
 				"arm64"
 			],
@@ -1458,12 +1545,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-			"integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+		"node_modules/@rolldown/binding-darwin-x64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+			"integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1472,26 +1562,15 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-			"integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
-			"cpu": [
-				"arm64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-			"integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+		"node_modules/@rolldown/binding-freebsd-x64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+			"integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1500,12 +1579,15 @@
 			"optional": true,
 			"os": [
 				"freebsd"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-			"integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+		"node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+			"integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
 			"cpu": [
 				"arm"
 			],
@@ -1514,26 +1596,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-			"integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
-			"cpu": [
-				"arm"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-			"integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+		"node_modules/@rolldown/binding-linux-arm64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+			"integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1542,12 +1613,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-			"integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+		"node_modules/@rolldown/binding-linux-arm64-musl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+			"integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1556,40 +1630,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-			"integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
-			"cpu": [
-				"loong64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-			"integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-			"integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+		"node_modules/@rolldown/binding-linux-ppc64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+			"integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1598,54 +1647,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-			"integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
-			"cpu": [
-				"ppc64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-			"integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-			"integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-			"integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+		"node_modules/@rolldown/binding-linux-s390x-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+			"integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
 			"cpu": [
 				"s390x"
 			],
@@ -1654,12 +1664,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-			"integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+		"node_modules/@rolldown/binding-linux-x64-gnu": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+			"integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
 			"cpu": [
 				"x64"
 			],
@@ -1668,12 +1681,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-			"integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+		"node_modules/@rolldown/binding-linux-x64-musl": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+			"integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
 			"cpu": [
 				"x64"
 			],
@@ -1682,26 +1698,15 @@
 			"optional": true,
 			"os": [
 				"linux"
-			]
-		},
-		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-			"integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
-			"cpu": [
-				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-			"integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+		"node_modules/@rolldown/binding-openharmony-arm64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+			"integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
 			"cpu": [
 				"arm64"
 			],
@@ -1710,12 +1715,34 @@
 			"optional": true,
 			"os": [
 				"openharmony"
-			]
+			],
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-			"integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+		"node_modules/@rolldown/binding-wasm32-wasi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+			"integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/core": "1.10.0",
+				"@emnapi/runtime": "1.10.0",
+				"@napi-rs/wasm-runtime": "^1.1.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/binding-win32-arm64-msvc": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+			"integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
 			"cpu": [
 				"arm64"
 			],
@@ -1724,26 +1751,15 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-			"integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
-			"cpu": [
-				"ia32"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
 		},
-		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-			"integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+		"node_modules/@rolldown/binding-win32-x64-msvc": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+			"integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
 			"cpu": [
 				"x64"
 			],
@@ -1752,27 +1768,22 @@
 			"optional": true,
 			"os": [
 				"win32"
-			]
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-			"integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
-			"cpu": [
-				"x64"
 			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
+			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+			"integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+			"devOptional": true,
+			"license": "MIT"
 		},
 		"node_modules/@sec-ant/readable-stream": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
 			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@semantic-release/changelog": {
@@ -2153,12 +2164,12 @@
 			}
 		},
 		"node_modules/@sindresorhus/is": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+			"integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -2181,14 +2192,48 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
 			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT"
+		},
+		"node_modules/@tybys/wasm-util": {
+			"version": "0.10.2",
+			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+			"integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
 		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
 			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/deep-eql": "*",
@@ -2199,14 +2244,20 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
 			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-			"dev": true,
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"devOptional": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
@@ -2227,31 +2278,31 @@
 			"license": "MIT"
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+			"integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@standard-schema/spec": "^1.0.0",
+				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"chai": "^6.2.1",
-				"tinyrainbow": "^3.0.3"
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"chai": "^6.2.2",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+			"integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.0.18",
+				"@vitest/spy": "4.1.5",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -2260,7 +2311,7 @@
 			},
 			"peerDependencies": {
 				"msw": "^2.4.9",
-				"vite": "^6.0.0 || ^7.0.0-0"
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"msw": {
@@ -2272,26 +2323,26 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+			"integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"tinyrainbow": "^3.0.3"
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+			"integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.0.18",
+				"@vitest/utils": "4.1.5",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -2299,13 +2350,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+			"integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/utils": "4.1.5",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -2314,27 +2366,37 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+			"integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://opencollective.com/vitest"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+			"integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.18",
-				"tinyrainbow": "^3.0.3"
+				"@vitest/pretty-format": "4.1.5",
+				"convert-source-map": "^2.0.0",
+				"tinyrainbow": "^3.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@xmldom/xmldom": {
+			"version": "0.9.10",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+			"integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.6"
 			}
 		},
 		"node_modules/agent-base": {
@@ -2356,6 +2418,65 @@
 			"dependencies": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-align": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.1.0"
+			}
+		},
+		"node_modules/ansi-align/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-align/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-align/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-align/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -2389,25 +2510,126 @@
 			}
 		},
 		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
 			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
+		},
+		"node_modules/any-base": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+			"integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+			"license": "MIT"
 		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"license": "MIT"
+		},
+		"node_modules/app-path": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/app-path/-/app-path-4.0.0.tgz",
+			"integrity": "sha512-mgBO9PZJ3MpbKbwFTljTi36ZKBvG5X/fkVR1F85ANsVcVllEb+C0LGNdJfGUm84GpC4xxgN6HFkmkMU8VEO4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"execa": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/app-path/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/app-path/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/app-path/node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/app-path/node_modules/is-stream": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/app-path/node_modules/npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/app-path/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC"
+		},
+		"node_modules/app-path/node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -2434,11 +2656,40 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
 			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/await-to-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+			"integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/before-after-hook": {
 			"version": "4.0.0",
@@ -2447,12 +2698,40 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
+		"node_modules/bmp-ts": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/bmp-ts/-/bmp-ts-1.0.9.tgz",
+			"integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==",
+			"license": "MIT"
+		},
 		"node_modules/bottleneck": {
 			"version": "2.19.5",
 			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
 			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/boxen": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+			"integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-align": "^3.0.1",
+				"camelcase": "^8.0.0",
+				"chalk": "^5.3.0",
+				"cli-boxes": "^3.0.0",
+				"string-width": "^7.2.0",
+				"type-fest": "^4.21.0",
+				"widest-line": "^5.0.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/braces": {
 			"version": "3.0.3",
@@ -2482,6 +2761,73 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/byte-counter": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+			"integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cacheable-lookup": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+			"integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/cacheable-request": {
+			"version": "13.0.19",
+			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
+			"integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-cache-semantics": "^4.2.0",
+				"get-stream": "^9.0.1",
+				"http-cache-semantics": "^4.2.0",
+				"keyv": "^5.6.0",
+				"mimic-response": "^4.0.0",
+				"normalize-url": "^8.1.1",
+				"responselike": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/cacheable-request/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cacheable-request/node_modules/normalize-url": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+			"integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2492,11 +2838,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camelcase": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+			"integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/chai": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
 			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -2533,6 +2891,33 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/cli-boxes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+			"integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/cli-highlight": {
 			"version": "2.1.11",
 			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
@@ -2554,6 +2939,21 @@
 				"npm": ">=5.0.0"
 			}
 		},
+		"node_modules/cli-highlight/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/cli-highlight/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2568,6 +2968,27 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/cli-table3": {
@@ -2585,6 +3006,56 @@
 				"@colors/colors": "1.5.0"
 			}
 		},
+		"node_modules/cli-table3/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-table3/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/cli-table3/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-table3/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cli-table3/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/cliui": {
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2594,6 +3065,88 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/cliui/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/color-convert": {
@@ -2731,6 +3284,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"devOptional": true,
+			"license": "MIT"
+		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -2788,7 +3348,6 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -2832,7 +3391,6 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -2844,6 +3402,21 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+			"integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/deep-extend": {
@@ -2896,6 +3469,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"devOptional": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2933,9 +3516,9 @@
 			}
 		},
 		"node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"license": "MIT"
 		},
 		"node_modules/emojilib": {
@@ -3122,53 +3705,11 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-			"dev": true,
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+			"devOptional": true,
 			"license": "MIT"
-		},
-		"node_modules/esbuild": {
-			"version": "0.27.4",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-			"integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.4",
-				"@esbuild/android-arm": "0.27.4",
-				"@esbuild/android-arm64": "0.27.4",
-				"@esbuild/android-x64": "0.27.4",
-				"@esbuild/darwin-arm64": "0.27.4",
-				"@esbuild/darwin-x64": "0.27.4",
-				"@esbuild/freebsd-arm64": "0.27.4",
-				"@esbuild/freebsd-x64": "0.27.4",
-				"@esbuild/linux-arm": "0.27.4",
-				"@esbuild/linux-arm64": "0.27.4",
-				"@esbuild/linux-ia32": "0.27.4",
-				"@esbuild/linux-loong64": "0.27.4",
-				"@esbuild/linux-mips64el": "0.27.4",
-				"@esbuild/linux-ppc64": "0.27.4",
-				"@esbuild/linux-riscv64": "0.27.4",
-				"@esbuild/linux-s390x": "0.27.4",
-				"@esbuild/linux-x64": "0.27.4",
-				"@esbuild/netbsd-arm64": "0.27.4",
-				"@esbuild/netbsd-x64": "0.27.4",
-				"@esbuild/openbsd-arm64": "0.27.4",
-				"@esbuild/openbsd-x64": "0.27.4",
-				"@esbuild/openharmony-arm64": "0.27.4",
-				"@esbuild/sunos-x64": "0.27.4",
-				"@esbuild/win32-arm64": "0.27.4",
-				"@esbuild/win32-ia32": "0.27.4",
-				"@esbuild/win32-x64": "0.27.4"
-			}
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -3196,7 +3737,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
@@ -3246,11 +3787,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/exif-parser": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+			"integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
 			"integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
@@ -3287,6 +3833,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
 			}
 		},
 		"node_modules/fill-range": {
@@ -3343,6 +3907,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/form-data-encoder": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-4.1.0.tgz",
+			"integrity": "sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
 			}
 		},
 		"node_modules/from2": {
@@ -3412,7 +3985,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
 			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -3434,6 +4006,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gifwrap": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.10.1.tgz",
+			"integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+			"license": "MIT",
+			"dependencies": {
+				"image-q": "^4.0.0",
+				"omggif": "^1.0.10"
+			}
+		},
 		"node_modules/git-log-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.1.tgz",
@@ -3447,6 +4029,32 @@
 				"stream-combiner2": "~1.1.1",
 				"through2": "~2.0.0",
 				"traverse": "0.6.8"
+			}
+		},
+		"node_modules/got": {
+			"version": "14.6.6",
+			"resolved": "https://registry.npmjs.org/got/-/got-14.6.6.tgz",
+			"integrity": "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==",
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/is": "^7.0.1",
+				"byte-counter": "^0.1.0",
+				"cacheable-lookup": "^7.0.0",
+				"cacheable-request": "^13.0.12",
+				"decompress-response": "^10.0.0",
+				"form-data-encoder": "^4.0.2",
+				"http2-wrapper": "^2.2.1",
+				"keyv": "^5.5.3",
+				"lowercase-keys": "^3.0.0",
+				"p-cancelable": "^4.0.1",
+				"responselike": "^4.0.2",
+				"type-fest": "^4.26.1"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
 		"node_modules/graceful-fs": {
@@ -3479,12 +4087,15 @@
 			}
 		},
 		"node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+			"integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/highlight.js": {
@@ -3522,6 +4133,12 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3534,6 +4151,19 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/http2-wrapper": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+			"integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=10.19.0"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -3559,6 +4189,56 @@
 			"engines": {
 				"node": ">=18.18.0"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/image-dimensions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/image-dimensions/-/image-dimensions-2.5.0.tgz",
+			"integrity": "sha512-CKZPHjAEtSg9lBV9eER0bhNn/yrY7cFEQEhkwjLhqLY+Na8lcP1pEyWsaGMGc8t2qbKWA/tuqbhFQpOKGN72Yw==",
+			"license": "MIT",
+			"bin": {
+				"image-dimensions": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/image-q": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+			"integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "16.9.1"
+			}
+		},
+		"node_modules/image-q/node_modules/@types/node": {
+			"version": "16.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+			"license": "MIT"
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
@@ -3689,12 +4369,18 @@
 			}
 		},
 		"node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+			"integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
 			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.3.1"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-inside-container": {
@@ -3752,7 +4438,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
 			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -3800,7 +4485,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/issue-parser": {
@@ -3820,6 +4504,22 @@
 				"node": "^18.17 || >=20.6.1"
 			}
 		},
+		"node_modules/iterm2-version": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/iterm2-version/-/iterm2-version-5.0.0.tgz",
+			"integrity": "sha512-WdLXcMYvN3SXT6vEtuW78vnZs4pVWm2nBnb4VKjOPPXmdlR1xTHmBgqKacOzAe4RXOiY/V+0u/0zsU3LoGQoBg==",
+			"license": "MIT",
+			"dependencies": {
+				"app-path": "^4.0.0",
+				"plist": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/java-properties": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
@@ -3829,6 +4529,50 @@
 			"engines": {
 				"node": ">= 0.6.0"
 			}
+		},
+		"node_modules/jimp": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.1.tgz",
+			"integrity": "sha512-hNQh6rZtWfSVWSNVmvq87N5BPJsNH7k7I7qyrXf9DOma9xATQk3fsyHazCQe51nCjdkoWdTmh0vD7bjVSLoxxw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jimp/core": "1.6.1",
+				"@jimp/diff": "1.6.1",
+				"@jimp/js-bmp": "1.6.1",
+				"@jimp/js-gif": "1.6.1",
+				"@jimp/js-jpeg": "1.6.1",
+				"@jimp/js-png": "1.6.1",
+				"@jimp/js-tiff": "1.6.1",
+				"@jimp/plugin-blit": "1.6.1",
+				"@jimp/plugin-blur": "1.6.1",
+				"@jimp/plugin-circle": "1.6.1",
+				"@jimp/plugin-color": "1.6.1",
+				"@jimp/plugin-contain": "1.6.1",
+				"@jimp/plugin-cover": "1.6.1",
+				"@jimp/plugin-crop": "1.6.1",
+				"@jimp/plugin-displace": "1.6.1",
+				"@jimp/plugin-dither": "1.6.1",
+				"@jimp/plugin-fisheye": "1.6.1",
+				"@jimp/plugin-flip": "1.6.1",
+				"@jimp/plugin-hash": "1.6.1",
+				"@jimp/plugin-mask": "1.6.1",
+				"@jimp/plugin-print": "1.6.1",
+				"@jimp/plugin-quantize": "1.6.1",
+				"@jimp/plugin-resize": "1.6.1",
+				"@jimp/plugin-rotate": "1.6.1",
+				"@jimp/plugin-threshold": "1.6.1",
+				"@jimp/types": "1.6.1",
+				"@jimp/utils": "1.6.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/jpeg-js": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+			"integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -3882,6 +4626,15 @@
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/keyv": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
 			}
 		},
 		"node_modules/lefthook": {
@@ -4047,6 +4800,267 @@
 				"win32"
 			]
 		},
+		"node_modules/lightningcss": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+			"integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+			"devOptional": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"detect-libc": "^2.0.3"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"lightningcss-android-arm64": "1.32.0",
+				"lightningcss-darwin-arm64": "1.32.0",
+				"lightningcss-darwin-x64": "1.32.0",
+				"lightningcss-freebsd-x64": "1.32.0",
+				"lightningcss-linux-arm-gnueabihf": "1.32.0",
+				"lightningcss-linux-arm64-gnu": "1.32.0",
+				"lightningcss-linux-arm64-musl": "1.32.0",
+				"lightningcss-linux-x64-gnu": "1.32.0",
+				"lightningcss-linux-x64-musl": "1.32.0",
+				"lightningcss-win32-arm64-msvc": "1.32.0",
+				"lightningcss-win32-x64-msvc": "1.32.0"
+			}
+		},
+		"node_modules/lightningcss-android-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+			"integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-arm64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+			"integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-darwin-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+			"integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-freebsd-x64": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+			"integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm-gnueabihf": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+			"integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+			"integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-arm64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+			"integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-gnu": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+			"integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-linux-x64-musl": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+			"integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-arm64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+			"integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/lightningcss-win32-x64-msvc": {
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+			"integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MPL-2.0",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 12.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4147,6 +5161,71 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/log-update": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-8.0.0.tgz",
+			"integrity": "sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.3.0",
+				"cli-cursor": "^5.0.0",
+				"slice-ansi": "^9.0.0",
+				"string-width": "^8.2.0",
+				"strip-ansi": "^7.2.0",
+				"wrap-ansi": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/string-width": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+			"integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/wrap-ansi": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+			"integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.3",
+				"string-width": "^8.2.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/lowercase-keys": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+			"integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "11.2.7",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -4161,7 +5240,7 @@
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
 			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -4186,36 +5265,35 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "15.0.12",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"version": "18.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+			"integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
 			"engines": {
-				"node": ">= 18"
+				"node": ">= 20"
 			}
 		},
-		"node_modules/marked-terminal": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
-			"integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+		"node_modules/marked-terminal-renderer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal-renderer/-/marked-terminal-renderer-2.2.0.tgz",
+			"integrity": "sha512-cUDuyNl4CyI3atFoDtxKL+zDsJAnLo/+1ETfJd8UvFVYRAltCbcPPa1UVEuS//N/85ZoGZFfqWyeRqyjXR37Wg==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-escapes": "^7.0.0",
-				"ansi-regex": "^6.1.0",
-				"chalk": "^5.4.1",
+				"ansi-regex": "^6.2.2",
+				"boxen": "^8.0.1",
+				"chalk": "^5.6.2",
 				"cli-highlight": "^2.1.11",
 				"cli-table3": "^0.6.5",
+				"got": "^14.6.5",
 				"node-emoji": "^2.2.0",
-				"supports-hyperlinks": "^3.1.0"
+				"terminal-image": "^4.1.0",
+				"terminal-link": "^5.0.0"
 			},
-			"engines": {
-				"node": ">=16.0.0"
-			},
-			"peerDependencies": {
-				"marked": ">=1 <16"
+			"bin": {
+				"catmd": "catmd.mjs"
 			}
 		},
 		"node_modules/meow": {
@@ -4235,7 +5313,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/micromatch": {
@@ -4272,10 +5349,33 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+			"integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/minimist": {
@@ -4292,7 +5392,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
@@ -4307,10 +5406,10 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"dev": true,
+			"version": "3.3.12",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4352,6 +5451,18 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/node-emoji/node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
 			}
 		},
 		"node_modules/normalize-package-data": {
@@ -6341,18 +7452,23 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
 			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
 			"license": "MIT"
 		},
+		"node_modules/omggif": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+			"integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+			"license": "MIT"
+		},
 		"node_modules/onetime": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
 			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mimic-fn": "^2.1.0"
@@ -6465,6 +7581,15 @@
 				"oxlint-tsgolint": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/p-cancelable": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-4.0.1.tgz",
+			"integrity": "sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
 			}
 		},
 		"node_modules/p-each-series": {
@@ -6594,6 +7719,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"license": "(MIT AND Zlib)"
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6605,6 +7736,28 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/parse-bmfont-ascii": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+			"integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+			"license": "MIT"
+		},
+		"node_modules/parse-bmfont-binary": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+			"integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+			"license": "MIT"
+		},
+		"node_modules/parse-bmfont-xml": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+			"integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+			"license": "MIT",
+			"dependencies": {
+				"xml-parse-from-string": "^1.0.0",
+				"xml2js": "^0.5.0"
 			}
 		},
 		"node_modules/parse-json": {
@@ -6673,7 +7826,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6693,14 +7845,14 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -6726,6 +7878,27 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/pixelmatch": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.3.0.tgz",
+			"integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+			"license": "ISC",
+			"dependencies": {
+				"pngjs": "^6.0.0"
+			},
+			"bin": {
+				"pixelmatch": "bin/pixelmatch"
+			}
+		},
+		"node_modules/pixelmatch/node_modules/pngjs": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+			"integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.13.0"
+			}
+		},
 		"node_modules/pkg-conf": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
@@ -6740,11 +7913,34 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/plist": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+			"integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@xmldom/xmldom": "^0.9.10",
+				"base64-js": "^1.5.1",
+				"xmlbuilder": "^15.1.1"
+			},
+			"engines": {
+				"node": ">=10.4.0"
+			}
+		},
+		"node_modules/pngjs": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+			"integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.19.0"
+			}
+		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-			"dev": true,
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6798,6 +7994,18 @@
 			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
@@ -6988,6 +8196,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/resolve-alpn": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+			"license": "MIT"
+		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -6998,49 +8212,84 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/rollup": {
-			"version": "4.60.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-			"integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
-			"dev": true,
+		"node_modules/responselike": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+			"integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "1.0.8"
-			},
-			"bin": {
-				"rollup": "dist/bin/rollup"
+				"lowercase-keys": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.0.0"
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/restore-cursor/node_modules/onetime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/rolldown": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+			"integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+			"devOptional": true,
+			"license": "MIT",
+			"dependencies": {
+				"@oxc-project/types": "=0.129.0",
+				"@rolldown/pluginutils": "1.0.0"
+			},
+			"bin": {
+				"rolldown": "bin/cli.mjs"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.12.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.60.0",
-				"@rollup/rollup-android-arm64": "4.60.0",
-				"@rollup/rollup-darwin-arm64": "4.60.0",
-				"@rollup/rollup-darwin-x64": "4.60.0",
-				"@rollup/rollup-freebsd-arm64": "4.60.0",
-				"@rollup/rollup-freebsd-x64": "4.60.0",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-				"@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-				"@rollup/rollup-linux-arm64-gnu": "4.60.0",
-				"@rollup/rollup-linux-arm64-musl": "4.60.0",
-				"@rollup/rollup-linux-loong64-gnu": "4.60.0",
-				"@rollup/rollup-linux-loong64-musl": "4.60.0",
-				"@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-				"@rollup/rollup-linux-ppc64-musl": "4.60.0",
-				"@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-				"@rollup/rollup-linux-riscv64-musl": "4.60.0",
-				"@rollup/rollup-linux-s390x-gnu": "4.60.0",
-				"@rollup/rollup-linux-x64-gnu": "4.60.0",
-				"@rollup/rollup-linux-x64-musl": "4.60.0",
-				"@rollup/rollup-openbsd-x64": "4.60.0",
-				"@rollup/rollup-openharmony-arm64": "4.60.0",
-				"@rollup/rollup-win32-arm64-msvc": "4.60.0",
-				"@rollup/rollup-win32-ia32-msvc": "4.60.0",
-				"@rollup/rollup-win32-x64-gnu": "4.60.0",
-				"@rollup/rollup-win32-x64-msvc": "4.60.0",
-				"fsevents": "~2.3.2"
+				"@rolldown/binding-android-arm64": "1.0.0",
+				"@rolldown/binding-darwin-arm64": "1.0.0",
+				"@rolldown/binding-darwin-x64": "1.0.0",
+				"@rolldown/binding-freebsd-x64": "1.0.0",
+				"@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+				"@rolldown/binding-linux-arm64-gnu": "1.0.0",
+				"@rolldown/binding-linux-arm64-musl": "1.0.0",
+				"@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+				"@rolldown/binding-linux-s390x-gnu": "1.0.0",
+				"@rolldown/binding-linux-x64-gnu": "1.0.0",
+				"@rolldown/binding-linux-x64-musl": "1.0.0",
+				"@rolldown/binding-openharmony-arm64": "1.0.0",
+				"@rolldown/binding-wasm32-wasi": "1.0.0",
+				"@rolldown/binding-win32-arm64-msvc": "1.0.0",
+				"@rolldown/binding-win32-x64-msvc": "1.0.0"
 			}
 		},
 		"node_modules/run-applescript": {
@@ -7061,6 +8310,15 @@
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/sax": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/semantic-release": {
 			"version": "25.0.3",
@@ -7132,19 +8390,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/semantic-release/node_modules/clean-stack": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.3.0.tgz",
@@ -7176,13 +8421,6 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/semantic-release/node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/semantic-release/node_modules/get-stream": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -7196,6 +8434,16 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/semantic-release/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/semantic-release/node_modules/indent-string": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -7207,6 +8455,41 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/semantic-release/node_modules/marked-terminal": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+			"integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.0.0",
+				"ansi-regex": "^6.1.0",
+				"chalk": "^5.4.1",
+				"cli-highlight": "^2.1.11",
+				"cli-table3": "^0.6.5",
+				"node-emoji": "^2.2.0",
+				"supports-hyperlinks": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"marked": ">=1 <16"
 			}
 		},
 		"node_modules/semantic-release/node_modules/p-reduce": {
@@ -7240,38 +8523,34 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/semantic-release/node_modules/string-width": {
+		"node_modules/semantic-release/node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
+				"has-flag": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=8"
 			}
 		},
-		"node_modules/semantic-release/node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+		"node_modules/semantic-release/node_modules/supports-hyperlinks": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.2.2"
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=14.18"
 			},
 			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
 			}
 		},
 		"node_modules/semantic-release/node_modules/type-fest": {
@@ -7288,24 +8567,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/semantic-release/node_modules/wrap-ansi": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/semantic-release/node_modules/yargs": {
@@ -7366,7 +8627,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -7379,7 +8639,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -7389,14 +8648,13 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -7511,6 +8769,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/simple-xml-to-json": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/simple-xml-to-json/-/simple-xml-to-json-1.2.7.tgz",
+			"integrity": "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.12.2"
+			}
+		},
 		"node_modules/skin-tone": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -7521,6 +8788,22 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/slice-ansi": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+			"integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.3",
+				"is-fullwidth-code-point": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
 		"node_modules/source-map": {
@@ -7537,7 +8820,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -7600,14 +8883,14 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
 			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/std-env": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-			"dev": true,
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+			"integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/stream-combiner2": {
@@ -7632,38 +8915,35 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^5.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/strip-bom": {
@@ -7699,6 +8979,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/super-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
@@ -7718,31 +9014,43 @@
 			}
 		},
 		"node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+			"integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
 			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
-			"integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.4.0.tgz",
+			"integrity": "sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==",
 			"license": "MIT",
 			"dependencies": {
-				"has-flag": "^4.0.0",
-				"supports-color": "^7.0.0"
+				"has-flag": "^5.0.1",
+				"supports-color": "^10.2.2"
 			},
 			"engines": {
-				"node": ">=14.18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+			}
+		},
+		"node_modules/supports-terminal-graphics": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/supports-terminal-graphics/-/supports-terminal-graphics-0.1.0.tgz",
+			"integrity": "sha512-+KdfozhS0Fw8y5Sghw8kkZNGT8nWYzJ1EzcoIvVjxhl+26TJTs26y02yfBgvc1jh5AS/c8jcI3xtahhR95KRyQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/tagged-tag": {
@@ -7813,6 +9121,59 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/term-img": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/term-img/-/term-img-7.1.0.tgz",
+			"integrity": "sha512-au++khgSDly2KXNhC6BOU3mLi2v+Dk5mChYKDcpB5xYwhlwqYQtj0z59dIqFEmr+w7ndZaNqurHapkGc6/hprQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.1.1",
+				"iterm2-version": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/terminal-image": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/terminal-image/-/terminal-image-4.3.0.tgz",
+			"integrity": "sha512-P4bCi7Ich17LgN/P2zM9sYbeleYNgu1Skk3q/uc15Ol9zWSiCldrCcIJ1Pd6dpgRGDmWhGVTgWHjV+ZMk1m/5g==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.6.2",
+				"image-dimensions": "^2.5.0",
+				"jimp": "^1.6.1",
+				"log-update": "^8.0.0",
+				"omggif": "^1.0.10",
+				"supports-terminal-graphics": "^0.1.0",
+				"term-img": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/terminal-link": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-5.0.0.tgz",
+			"integrity": "sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.0.0",
+				"supports-hyperlinks": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -7865,28 +9226,34 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
 			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-			"dev": true,
+			"devOptional": true,
+			"license": "MIT"
+		},
+		"node_modules/tinycolor2": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+			"integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
 			"license": "MIT"
 		},
 		"node_modules/tinyexec": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
 			"integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-			"dev": true,
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -7899,7 +9266,7 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
@@ -7917,7 +9284,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -7940,7 +9307,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
 			"integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -7959,6 +9326,24 @@
 				"node": ">=8.0"
 			}
 		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/traverse": {
 			"version": "0.6.8",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
@@ -7971,6 +9356,14 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD",
+			"optional": true
 		},
 		"node_modules/tunnel": {
 			"version": "0.0.6",
@@ -7986,7 +9379,6 @@
 			"version": "4.41.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
 			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
@@ -8021,6 +9413,18 @@
 			},
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/undici": {
@@ -8104,6 +9508,15 @@
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
+		"node_modules/utif2": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/utif2/-/utif2-4.1.0.tgz",
+			"integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^1.0.11"
+			}
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8123,18 +9536,17 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-			"dev": true,
+			"version": "8.0.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+			"integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.27.0",
-				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3",
-				"postcss": "^8.5.6",
-				"rollup": "^4.43.0",
-				"tinyglobby": "^0.2.15"
+				"lightningcss": "^1.32.0",
+				"picomatch": "^4.0.4",
+				"postcss": "^8.5.14",
+				"rolldown": "1.0.0",
+				"tinyglobby": "^0.2.16"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -8150,9 +9562,10 @@
 			},
 			"peerDependencies": {
 				"@types/node": "^20.19.0 || >=22.12.0",
+				"@vitejs/devtools": "^0.1.18",
+				"esbuild": "^0.27.0 || ^0.28.0",
 				"jiti": ">=1.21.0",
 				"less": "^4.0.0",
-				"lightningcss": "^1.21.0",
 				"sass": "^1.70.0",
 				"sass-embedded": "^1.70.0",
 				"stylus": ">=0.54.8",
@@ -8165,13 +9578,16 @@
 				"@types/node": {
 					"optional": true
 				},
+				"@vitejs/devtools": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
 				"jiti": {
 					"optional": true
 				},
 				"less": {
-					"optional": true
-				},
-				"lightningcss": {
 					"optional": true
 				},
 				"sass": {
@@ -8197,29 +9613,11 @@
 				}
 			}
 		},
-		"node_modules/vite/node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/vite/node_modules/picomatch": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -8229,31 +9627,31 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
-			"dev": true,
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+			"integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.0.18",
-				"@vitest/mocker": "4.0.18",
-				"@vitest/pretty-format": "4.0.18",
-				"@vitest/runner": "4.0.18",
-				"@vitest/snapshot": "4.0.18",
-				"@vitest/spy": "4.0.18",
-				"@vitest/utils": "4.0.18",
-				"es-module-lexer": "^1.7.0",
-				"expect-type": "^1.2.2",
+				"@vitest/expect": "4.1.5",
+				"@vitest/mocker": "4.1.5",
+				"@vitest/pretty-format": "4.1.5",
+				"@vitest/runner": "4.1.5",
+				"@vitest/snapshot": "4.1.5",
+				"@vitest/spy": "4.1.5",
+				"@vitest/utils": "4.1.5",
+				"es-module-lexer": "^2.0.0",
+				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
 				"obug": "^2.1.1",
 				"pathe": "^2.0.3",
 				"picomatch": "^4.0.3",
-				"std-env": "^3.10.0",
+				"std-env": "^4.0.0-rc.1",
 				"tinybench": "^2.9.0",
 				"tinyexec": "^1.0.2",
 				"tinyglobby": "^0.2.15",
-				"tinyrainbow": "^3.0.3",
-				"vite": "^6.0.0 || ^7.0.0",
+				"tinyrainbow": "^3.1.0",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -8269,12 +9667,15 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.0.18",
-				"@vitest/browser-preview": "4.0.18",
-				"@vitest/browser-webdriverio": "4.0.18",
-				"@vitest/ui": "4.0.18",
+				"@vitest/browser-playwright": "4.1.5",
+				"@vitest/browser-preview": "4.1.5",
+				"@vitest/browser-webdriverio": "4.1.5",
+				"@vitest/coverage-istanbul": "4.1.5",
+				"@vitest/coverage-v8": "4.1.5",
+				"@vitest/ui": "4.1.5",
 				"happy-dom": "*",
-				"jsdom": "*"
+				"jsdom": "*",
+				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@edge-runtime/vm": {
@@ -8295,6 +9696,12 @@
 				"@vitest/browser-webdriverio": {
 					"optional": true
 				},
+				"@vitest/coverage-istanbul": {
+					"optional": true
+				},
+				"@vitest/coverage-v8": {
+					"optional": true
+				},
 				"@vitest/ui": {
 					"optional": true
 				},
@@ -8303,6 +9710,9 @@
 				},
 				"jsdom": {
 					"optional": true
+				},
+				"vite": {
+					"optional": false
 				}
 			}
 		},
@@ -8310,7 +9720,7 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -8330,7 +9740,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -8346,7 +9755,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
 			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"siginfo": "^2.0.0",
@@ -8359,6 +9768,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/widest-line": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+			"integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -8367,17 +9791,17 @@
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -8396,6 +9820,43 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/xml-parse-from-string": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+			"integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+			"license": "MIT"
+		},
+		"node_modules/xml2js": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+			"integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xml2js/node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+			"integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0"
 			}
 		},
 		"node_modules/xtend": {
@@ -8444,10 +9905,60 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/yargs/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/yocto-spinner": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.0.0.tgz",
-			"integrity": "sha512-VPX8P/+Z2Fnpx8PC/JELbxp3QRrBxjAekio6yulGtA5gKt9YyRc5ycCb+NHgZCbZ0kx9KxwZp7gC6UlrCcCdSQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.1.0.tgz",
+			"integrity": "sha512-/BY0AUXnS7IKO354uLLA2eRcWiqDifEbd6unXCsOxkFDAkhgUL3PH9X2bFoaU0YchnDXsF+iKleeTLJGckbXfA==",
 			"license": "MIT",
 			"dependencies": {
 				"yoctocolors": "^2.1.1"
@@ -8469,6 +9980,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
 		"node": ">=20.18.1"
 	},
 	"dependencies": {
+		"@doist/cli-core": "0.9.0",
 		"chalk": "5.6.2",
 		"commander": "14.0.2",
-		"marked": "15.0.12",
-		"marked-terminal": "7.3.0",
+		"marked": "18.0.3",
+		"marked-terminal-renderer": "2.2.0",
 		"open": "10.2.0",
-		"undici": "7.22.0",
-		"yocto-spinner": "1.0.0"
+		"undici": "7.22.0"
 	},
 	"devDependencies": {
 		"@semantic-release/changelog": "6.0.3",
@@ -66,6 +66,6 @@
 		"oxlint": "1.57.0",
 		"semantic-release": "25.0.3",
 		"typescript": "5.9.3",
-		"vitest": "4.0.18"
+		"vitest": "4.1.5"
 	}
 }

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/auth.js', () => ({
-    getApiToken: () => 'test-token',
-    getBaseUrl: () => 'https://test.outline.com',
+    getApiToken: async () => 'test-token',
+    getBaseUrl: async () => 'https://test.outline.com',
 }))
 
 vi.mock('../transport/fetch-with-retry.js', () => ({

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -3,20 +3,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const TEST_HOME = join(tmpdir(), `outline-cli-test-${process.pid}`)
-const TEST_CONFIG_DIR = join(TEST_HOME, '.config', 'outline-cli')
+const TEST_XDG = join(tmpdir(), `outline-cli-test-${process.pid}`)
+const TEST_CONFIG_DIR = join(TEST_XDG, 'outline-cli')
 const TEST_CONFIG_PATH = join(TEST_CONFIG_DIR, 'config.json')
-
-vi.mock('node:os', async () => {
-    const actual = await vi.importActual<typeof import('node:os')>('node:os')
-    return {
-        ...actual,
-        homedir: () => join(tmpdir(), `outline-cli-test-${process.pid}`),
-    }
-})
 
 describe('auth', () => {
     beforeEach(() => {
+        process.env.XDG_CONFIG_HOME = TEST_XDG
         mkdirSync(TEST_CONFIG_DIR, { recursive: true })
         delete process.env.OUTLINE_API_TOKEN
         delete process.env.OUTLINE_URL
@@ -25,9 +18,10 @@ describe('auth', () => {
     })
 
     afterEach(() => {
-        if (existsSync(TEST_HOME)) {
-            rmSync(TEST_HOME, { recursive: true })
+        if (existsSync(TEST_XDG)) {
+            rmSync(TEST_XDG, { recursive: true })
         }
+        delete process.env.XDG_CONFIG_HOME
     })
 
     it('getApiToken reads from env var first', async () => {

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -21,68 +21,68 @@ describe('auth', () => {
         delete process.env.OUTLINE_API_TOKEN
         delete process.env.OUTLINE_URL
         delete process.env.OUTLINE_OAUTH_CLIENT_ID
+        vi.resetModules()
     })
 
     afterEach(() => {
         if (existsSync(TEST_HOME)) {
             rmSync(TEST_HOME, { recursive: true })
         }
-        vi.resetModules()
     })
 
     it('getApiToken reads from env var first', async () => {
         process.env.OUTLINE_API_TOKEN = 'env-token'
         const { getApiToken } = await import('../lib/auth.js')
-        expect(getApiToken()).toBe('env-token')
+        await expect(getApiToken()).resolves.toBe('env-token')
     })
 
     it('getApiToken reads from config file', async () => {
         writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ api_token: 'file-token' }))
         const { getApiToken } = await import('../lib/auth.js')
-        expect(getApiToken()).toBe('file-token')
+        await expect(getApiToken()).resolves.toBe('file-token')
     })
 
     it('getApiToken throws when no token available', async () => {
         const { getApiToken } = await import('../lib/auth.js')
-        expect(() => getApiToken()).toThrow('No API token found')
+        await expect(getApiToken()).rejects.toThrow('No API token found')
     })
 
     it('getBaseUrl returns env var first', async () => {
         process.env.OUTLINE_URL = 'https://custom.example.com'
         const { getBaseUrl } = await import('../lib/auth.js')
-        expect(getBaseUrl()).toBe('https://custom.example.com')
+        await expect(getBaseUrl()).resolves.toBe('https://custom.example.com')
     })
 
     it('getBaseUrl strips trailing slash', async () => {
         process.env.OUTLINE_URL = 'https://custom.example.com/'
         const { getBaseUrl } = await import('../lib/auth.js')
-        expect(getBaseUrl()).toBe('https://custom.example.com')
+        await expect(getBaseUrl()).resolves.toBe('https://custom.example.com')
     })
 
     it('getBaseUrl returns default when nothing configured', async () => {
         const { getBaseUrl } = await import('../lib/auth.js')
-        expect(getBaseUrl()).toBe('https://app.getoutline.com')
+        await expect(getBaseUrl()).resolves.toBe('https://app.getoutline.com')
     })
 
     it('saveConfig and clearConfig work', async () => {
         const { saveConfig, clearConfig, getApiToken, getOAuthClientId } =
             await import('../lib/auth.js')
-        saveConfig('test-token', 'https://wiki.test.com', 'client-id')
-        expect(getApiToken()).toBe('test-token')
-        expect(getOAuthClientId()).toBe('client-id')
-        clearConfig()
-        expect(() => getApiToken()).toThrow()
+        await saveConfig('test-token', 'https://wiki.test.com', 'client-id')
+        await expect(getApiToken()).resolves.toBe('test-token')
+        await expect(getOAuthClientId()).resolves.toBe('client-id')
+        await clearConfig()
+        await expect(getApiToken()).rejects.toThrow()
     })
 
     it('getOAuthClientId returns env var first', async () => {
         process.env.OUTLINE_OAUTH_CLIENT_ID = 'env-client-id'
         const { getOAuthClientId } = await import('../lib/auth.js')
-        expect(getOAuthClientId()).toBe('env-client-id')
+        await expect(getOAuthClientId()).resolves.toBe('env-client-id')
     })
 
     it('getOAuthClientId reads from config file', async () => {
         writeFileSync(TEST_CONFIG_PATH, JSON.stringify({ oauth_client_id: 'file-client-id' }))
         const { getOAuthClientId } = await import('../lib/auth.js')
-        expect(getOAuthClientId()).toBe('file-client-id')
+        await expect(getOAuthClientId()).resolves.toBe('file-client-id')
     })
 })

--- a/src/__tests__/commands.test.ts
+++ b/src/__tests__/commands.test.ts
@@ -2,9 +2,10 @@ import { Command } from 'commander'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/auth.js', () => ({
-    getApiToken: () => 'test-token',
-    getBaseUrl: () => 'https://test.outline.com',
-    getTokenSource: () => 'config' as const,
+    getApiToken: async () => 'test-token',
+    getBaseUrl: async () => 'https://test.outline.com',
+    getOAuthClientId: async () => undefined,
+    getTokenSource: async () => 'config' as const,
     saveConfig: vi.fn(),
     clearConfig: vi.fn(),
 }))
@@ -122,7 +123,8 @@ describe('document commands', () => {
         await program.parseAsync(['node', 'ol', 'document', 'get', 'my-doc-abc123'])
 
         expect(apiRequest).toHaveBeenCalledWith('documents.info', { id: 'abc123' })
-        expect(logs[0]).toContain('# My Doc')
+        expect(logs[0]).toContain('My Doc')
+        expect(logs[0]).toContain('Hello world')
     })
 
     it('document list passes pagination options', async () => {

--- a/src/__tests__/output.test.ts
+++ b/src/__tests__/output.test.ts
@@ -38,11 +38,14 @@ describe('output', () => {
 
     it('outputList ndjson mode', () => {
         outputList([item, { ...item, id: '2' }], formatter, keys, { ndjson: true })
-        expect(logs).toHaveLength(1)
-        const lines = logs[0].split('\n')
-        expect(lines).toHaveLength(2)
-        expect(JSON.parse(lines[0])).toEqual({ id: '1', name: 'Test' })
-        expect(JSON.parse(lines[1])).toEqual({ id: '2', name: 'Test' })
+        const records = logs
+            .flatMap((line) => line.split('\n'))
+            .filter(Boolean)
+            .map((line) => JSON.parse(line))
+        expect(records).toEqual([
+            { id: '1', name: 'Test' },
+            { id: '2', name: 'Test' },
+        ])
     })
 
     it('getOutputOptions parses flags', () => {

--- a/src/__tests__/output.test.ts
+++ b/src/__tests__/output.test.ts
@@ -38,9 +38,11 @@ describe('output', () => {
 
     it('outputList ndjson mode', () => {
         outputList([item, { ...item, id: '2' }], formatter, keys, { ndjson: true })
-        expect(logs).toHaveLength(2)
-        expect(JSON.parse(logs[0])).toEqual({ id: '1', name: 'Test' })
-        expect(JSON.parse(logs[1])).toEqual({ id: '2', name: 'Test' })
+        expect(logs).toHaveLength(1)
+        const lines = logs[0].split('\n')
+        expect(lines).toHaveLength(2)
+        expect(JSON.parse(lines[0])).toEqual({ id: '1', name: 'Test' })
+        expect(JSON.parse(lines[1])).toEqual({ id: '2', name: 'Test' })
     })
 
     it('getOutputOptions parses flags', () => {

--- a/src/__tests__/refs.test.ts
+++ b/src/__tests__/refs.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('../lib/auth.js', () => ({
-    getApiToken: () => 'test-token',
-    getBaseUrl: () => 'https://test.outline.com',
+    getApiToken: async () => 'test-token',
+    getBaseUrl: async () => 'https://test.outline.com',
 }))
 
 const mockApiRequest = vi.fn()

--- a/src/__tests__/spinner.test.ts
+++ b/src/__tests__/spinner.test.ts
@@ -1,200 +1,33 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { LoadingSpinner, withSpinner } from '../lib/spinner.js'
+import { describe, expect, it, vi } from 'vitest'
 
-const mockSpinnerInstance = {
-    start: vi.fn().mockReturnThis(),
-    success: vi.fn(),
-    error: vi.fn(),
-    stop: vi.fn(),
-}
-
-vi.mock('yocto-spinner', () => ({
-    default: vi.fn(() => mockSpinnerInstance),
-}))
-
-vi.mock('chalk', () => ({
-    default: {
-        green: (text: string) => text,
-        yellow: (text: string) => text,
-        blue: (text: string) => text,
-        red: (text: string) => text,
+const createSpinnerMock = vi.fn(() => ({
+    LoadingSpinner: class {
+        start() {
+            return this
+        }
+        succeed() {}
+        fail() {}
+        stop() {}
     },
+    withSpinner: async <T>(_opts: unknown, fn: () => Promise<T>) => fn(),
+    startEarlySpinner: vi.fn(),
+    stopEarlySpinner: vi.fn(),
+    resetEarlySpinner: vi.fn(),
 }))
 
-describe('withSpinner', () => {
-    beforeEach(() => {
-        vi.clearAllMocks()
-        delete process.env.OL_SPINNER
-        delete process.env.CI
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: true,
-            configurable: true,
-        })
-        process.argv = ['node', 'ol']
-    })
-
-    afterEach(() => {
-        vi.clearAllMocks()
-    })
-
-    it('handles successful operations', async () => {
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalled()
-        expect(mockSpinnerInstance.error).not.toHaveBeenCalled()
-    })
-
-    it('handles failed operations', async () => {
-        await expect(
-            withSpinner({ text: 'Testing...', color: 'blue' }, async () => {
-                throw new Error('test error')
-            }),
-        ).rejects.toThrow('test error')
-
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-        expect(mockSpinnerInstance.error).toHaveBeenCalled()
-        expect(mockSpinnerInstance.stop).not.toHaveBeenCalled()
-    })
-
-    it('skips spinner when noSpinner option is true', async () => {
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue', noSpinner: true },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('skips spinner when OL_SPINNER=false', async () => {
-        process.env.OL_SPINNER = 'false'
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('skips spinner in CI environment', async () => {
-        process.env.CI = 'true'
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('skips spinner when not in TTY', async () => {
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: false,
-            configurable: true,
-        })
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('skips spinner with --json flag', async () => {
-        process.argv = ['node', 'ol', 'search', '--json']
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('skips spinner with --ndjson flag', async () => {
-        process.argv = ['node', 'ol', 'search', '--ndjson']
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
-
-    it('skips spinner with --no-spinner flag', async () => {
-        process.argv = ['node', 'ol', 'auth', 'status', '--no-spinner']
-
-        const result = await withSpinner(
-            { text: 'Testing...', color: 'blue' },
-            async () => 'success',
-        )
-
-        expect(result).toBe('success')
-        expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
-    })
+vi.mock('@doist/cli-core', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@doist/cli-core')>()
+    return {
+        ...actual,
+        createSpinner: createSpinnerMock,
+    }
 })
 
-describe('LoadingSpinner', () => {
-    beforeEach(() => {
-        vi.clearAllMocks()
-        delete process.env.OL_SPINNER
-        delete process.env.CI
-        Object.defineProperty(process.stdout, 'isTTY', {
-            value: true,
-            configurable: true,
-        })
-        process.argv = ['node', 'ol']
-    })
-
-    it('starts and stops', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        expect(mockSpinnerInstance.start).toHaveBeenCalled()
-
-        spinner.stop()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalled()
-    })
-
-    it('shows success message', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        spinner.succeed('Done')
-        expect(mockSpinnerInstance.success).toHaveBeenCalledWith('✓ Done')
-    })
-
-    it('shows failure message', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        spinner.fail('Failed')
-        expect(mockSpinnerInstance.error).toHaveBeenCalledWith('✗ Failed')
-    })
-
-    it('handles multiple stop calls gracefully', () => {
-        const spinner = new LoadingSpinner()
-        spinner.start({ text: 'Testing...', color: 'blue' })
-        spinner.stop()
-        spinner.stop()
-        expect(mockSpinnerInstance.stop).toHaveBeenCalledTimes(1)
-    })
-
-    it('handles succeed/fail without starting', () => {
-        const spinner = new LoadingSpinner()
-        spinner.succeed('Test')
-        spinner.fail('Test')
-        expect(mockSpinnerInstance.success).not.toHaveBeenCalled()
-        expect(mockSpinnerInstance.error).not.toHaveBeenCalled()
+describe('spinner wiring', () => {
+    it('builds the kit with the OL-specific isDisabled gate', async () => {
+        await import('../lib/spinner.js')
+        expect(createSpinnerMock).toHaveBeenCalledTimes(1)
+        const config = createSpinnerMock.mock.calls[0]?.[0] as { isDisabled?: () => boolean }
+        expect(typeof config.isDisabled).toBe('function')
     })
 })

--- a/src/__tests__/spinner.test.ts
+++ b/src/__tests__/spinner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const createSpinnerMock = vi.fn(() => ({
     LoadingSpinner: class {
@@ -24,10 +24,59 @@ vi.mock('@doist/cli-core', async (importOriginal) => {
 })
 
 describe('spinner wiring', () => {
-    it('builds the kit with the OL-specific isDisabled gate', async () => {
+    beforeEach(() => {
+        delete process.env.OL_SPINNER
+        delete process.env.CI
+        process.argv = ['node', 'ol']
+    })
+
+    afterEach(() => {
+        delete process.env.OL_SPINNER
+        delete process.env.CI
+        process.argv = ['node', 'ol']
+    })
+
+    async function loadIsDisabled(): Promise<() => boolean> {
+        vi.resetModules()
+        createSpinnerMock.mockClear()
         await import('../lib/spinner.js')
-        expect(createSpinnerMock).toHaveBeenCalledTimes(1)
-        const config = createSpinnerMock.mock.calls[0]?.[0] as { isDisabled?: () => boolean }
-        expect(typeof config.isDisabled).toBe('function')
+        expect(createSpinnerMock).toHaveBeenCalledWith(
+            expect.objectContaining({ isDisabled: expect.any(Function) }),
+        )
+        return createSpinnerMock.mock.calls[0]![0]!.isDisabled!
+    }
+
+    it('does not disable by default', async () => {
+        expect((await loadIsDisabled())()).toBe(false)
+    })
+
+    it('disables when OL_SPINNER=false', async () => {
+        process.env.OL_SPINNER = 'false'
+        expect((await loadIsDisabled())()).toBe(true)
+    })
+
+    it('disables when CI=1', async () => {
+        process.env.CI = '1'
+        expect((await loadIsDisabled())()).toBe(true)
+    })
+
+    it('honours CI=false as an opt-out (does not disable)', async () => {
+        process.env.CI = 'false'
+        expect((await loadIsDisabled())()).toBe(false)
+    })
+
+    it('disables when --json is in argv', async () => {
+        process.argv = ['node', 'ol', 'search', 'foo', '--json']
+        expect((await loadIsDisabled())()).toBe(true)
+    })
+
+    it('disables when --ndjson is in argv', async () => {
+        process.argv = ['node', 'ol', 'search', 'foo', '--ndjson']
+        expect((await loadIsDisabled())()).toBe(true)
+    })
+
+    it('disables when --no-spinner is in argv', async () => {
+        process.argv = ['node', 'ol', 'auth', 'status', '--no-spinner']
+        expect((await loadIsDisabled())()).toBe(true)
     })
 })

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -67,7 +67,7 @@ export function registerAuthCommand(program: Command): void {
                 baseUrl?: string
                 callbackPort?: string
             }) => {
-                const configuredBaseUrl = getBaseUrl()
+                const configuredBaseUrl = await getBaseUrl()
                 const optionBaseUrl = options.baseUrl?.trim()
                 const envBaseUrl = process.env.OUTLINE_URL?.trim()
                 let url = optionBaseUrl || envBaseUrl
@@ -101,7 +101,7 @@ export function registerAuthCommand(program: Command): void {
                 }
 
                 if (options.token) {
-                    saveConfig(options.token.trim(), url, optionClientId)
+                    await saveConfig(options.token.trim(), url, optionClientId)
                     try {
                         const { data } = await apiRequest<AuthInfoResponse>('auth.info')
                         console.log(
@@ -116,7 +116,7 @@ export function registerAuthCommand(program: Command): void {
                     return
                 }
 
-                const existingClientId = getOAuthClientId()
+                const existingClientId = await getOAuthClientId()
                 let clientId = optionClientId || existingClientId
 
                 if (!clientId) {
@@ -196,7 +196,7 @@ export function registerAuthCommand(program: Command): void {
                         code,
                     })
 
-                    saveConfig(token, url, clientId)
+                    await saveConfig(token, url, clientId)
 
                     const { data } = await apiRequest<AuthInfoResponse>('auth.info')
                     console.log(
@@ -223,14 +223,14 @@ export function registerAuthCommand(program: Command): void {
     auth.command('status')
         .description('Show current authentication state')
         .action(async () => {
-            const source = getTokenSource()
+            const source = await getTokenSource()
             if (!source) {
                 console.log(chalk.yellow('Not authenticated. Run: ol auth login'))
                 return
             }
 
             console.log(chalk.dim(`Token source: ${source}`))
-            console.log(chalk.dim(`Base URL: ${getBaseUrl()}`))
+            console.log(chalk.dim(`Base URL: ${await getBaseUrl()}`))
 
             try {
                 const { data } = await apiRequest<AuthInfoResponse>('auth.info')
@@ -254,8 +254,8 @@ export function registerAuthCommand(program: Command): void {
 
     auth.command('logout')
         .description('Clear saved authentication')
-        .action(() => {
-            clearConfig()
+        .action(async () => {
+            await clearConfig()
             console.log('Logged out.')
         })
 }

--- a/src/commands/document.ts
+++ b/src/commands/document.ts
@@ -105,7 +105,7 @@ export function registerDocumentCommand(program: Command): void {
                 outputItem(data, formatDocFull, essentialKeys, outputOpts)
             } else {
                 const content = formatDocFull(data)
-                console.log(opts.raw ? content : renderMarkdown(content))
+                console.log(opts.raw ? content : await renderMarkdown(content))
             }
         })
 
@@ -113,7 +113,7 @@ export function registerDocumentCommand(program: Command): void {
         .description('Open a document in the browser')
         .action(async (id: string) => {
             const resolved = await resolveDocumentRef(id)
-            const fullUrl = `${getBaseUrl()}${resolved.url}`
+            const fullUrl = `${await getBaseUrl()}${resolved.url}`
             await open(fullUrl)
             console.log(chalk.dim(`Opened: ${fullUrl}`))
         })

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -18,17 +18,19 @@ interface SearchResult {
 
 const essentialKeys: (keyof SearchResult)[] = ['document', 'context']
 
-function formatResult(result: SearchResult): string {
-    const { document, context } = result
-    const title = chalk.bold(document.title)
-    const id = chalk.dim(document.urlId)
-    const link = chalk.dim(`${getBaseUrl()}${document.url}`)
-    const snippet = context
-        .replace(/<b>(.*?)<\/b>/g, (_, m) => chalk.bold(m))
-        .replace(/<\/?b>/g, '')
-        .trim()
-        .slice(0, 120)
-    return `${title} ${id}\n  ${link}\n  ${chalk.dim(snippet)}\n`
+function makeFormatResult(baseUrl: string): (result: SearchResult) => string {
+    return (result) => {
+        const { document, context } = result
+        const title = chalk.bold(document.title)
+        const id = chalk.dim(document.urlId)
+        const link = chalk.dim(`${baseUrl}${document.url}`)
+        const snippet = context
+            .replace(/<b>(.*?)<\/b>/g, (_, m) => chalk.bold(m))
+            .replace(/<\/?b>/g, '')
+            .trim()
+            .slice(0, 120)
+        return `${title} ${id}\n  ${link}\n  ${chalk.dim(snippet)}\n`
+    }
 }
 
 export function registerSearchCommand(program: Command): void {
@@ -52,6 +54,7 @@ export function registerSearchCommand(program: Command): void {
             const { data, pagination } = await apiRequest<SearchResult[]>('documents.search', body)
 
             const outputOpts = getOutputOptions(opts)
+            const formatResult = makeFormatResult(await getBaseUrl())
             outputList(data, formatResult, essentialKeys, outputOpts, pagination)
         })
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -54,7 +54,10 @@ export function registerSearchCommand(program: Command): void {
             const { data, pagination } = await apiRequest<SearchResult[]>('documents.search', body)
 
             const outputOpts = getOutputOptions(opts)
-            const formatResult = makeFormatResult(await getBaseUrl())
+            const formatResult =
+                outputOpts.json || outputOpts.ndjson
+                    ? () => ''
+                    : makeFormatResult(await getBaseUrl())
             outputList(data, formatResult, essentialKeys, outputOpts, pagination)
         })
 }

--- a/src/commands/update/action.ts
+++ b/src/commands/update/action.ts
@@ -95,7 +95,7 @@ export async function updateAction(options: { check?: boolean; channel?: boolean
     }
 
     if (options.channel) {
-        const ch = getUpdateChannel()
+        const ch = await getUpdateChannel()
         if (ch === 'pre-release') {
             console.log(`Update channel: ${chalk.magenta('pre-release')}`)
         } else {
@@ -104,7 +104,7 @@ export async function updateAction(options: { check?: boolean; channel?: boolean
         return
     }
 
-    const channel = getUpdateChannel()
+    const channel = await getUpdateChannel()
     const tag = getInstallTag(channel)
     const label = channelLabel(channel)
 

--- a/src/commands/update/switch.ts
+++ b/src/commands/update/switch.ts
@@ -1,7 +1,10 @@
 import chalk from 'chalk'
 import { setUpdateChannel, type UpdateChannel } from '../../lib/update-config.js'
 
-export function switchChannel(options: { stable?: boolean; preRelease?: boolean }): void {
+export async function switchChannel(options: {
+    stable?: boolean
+    preRelease?: boolean
+}): Promise<void> {
     if (options.stable && options.preRelease) {
         console.error(chalk.red('Error:'), 'Specify either --stable or --pre-release, not both.')
         process.exitCode = 1
@@ -16,7 +19,7 @@ export function switchChannel(options: { stable?: boolean; preRelease?: boolean 
 
     const channel: UpdateChannel = options.preRelease ? 'pre-release' : 'stable'
 
-    setUpdateChannel(channel)
+    await setUpdateChannel(channel)
 
     if (channel === 'pre-release') {
         console.log(chalk.green('✓'), `Update channel set to ${chalk.magenta('pre-release')}`)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -51,8 +51,7 @@ export interface PaginatedResult<T> {
  * Core API request function without spinner wrapping.
  */
 async function rawApiRequest<T>(path: string, body: object = {}): Promise<PaginatedResult<T>> {
-    const baseUrl = getBaseUrl()
-    const token = getApiToken()
+    const [baseUrl, token] = await Promise.all([getBaseUrl(), getApiToken()])
 
     const res = await fetchWithRetry({
         url: `${baseUrl}/api/${path}`,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,64 +1,49 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { unlink } from 'node:fs/promises'
+import { type Config, getConfig, getConfigPath, setConfig } from './config.js'
 
-interface Config {
-    api_token?: string
-    base_url?: string
-    oauth_client_id?: string
-}
-
-const CONFIG_DIR = join(homedir(), '.config', 'outline-cli')
-const CONFIG_PATH = join(CONFIG_DIR, 'config.json')
 const DEFAULT_BASE_URL = 'https://app.getoutline.com'
 
-function readConfig(): Config {
-    if (!existsSync(CONFIG_PATH)) return {}
-    try {
-        return JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
-    } catch {
-        return {}
-    }
-}
-
-export function getApiToken(): string {
+export async function getApiToken(): Promise<string> {
     const envToken = process.env.OUTLINE_API_TOKEN
     if (envToken) return envToken
 
-    const config = readConfig()
+    const config = await getConfig()
     if (config.api_token) return config.api_token
 
     throw new Error('No API token found. Set OUTLINE_API_TOKEN env var or run: ol auth login')
 }
 
-export function getBaseUrl(): string {
+export async function getBaseUrl(): Promise<string> {
     const envUrl = process.env.OUTLINE_URL
     if (envUrl) return envUrl.replace(/\/$/, '')
 
-    const config = readConfig()
+    const config = await getConfig()
     if (config.base_url) return config.base_url.replace(/\/$/, '')
 
     return DEFAULT_BASE_URL
 }
 
-export function getOAuthClientId(): string | undefined {
+export async function getOAuthClientId(): Promise<string | undefined> {
     const envClientId = process.env.OUTLINE_OAUTH_CLIENT_ID
     if (envClientId) return envClientId
 
-    const config = readConfig()
+    const config = await getConfig()
     return config.oauth_client_id
 }
 
-export function getTokenSource(): 'env' | 'config' | null {
+export async function getTokenSource(): Promise<'env' | 'config' | null> {
     if (process.env.OUTLINE_API_TOKEN) return 'env'
-    const config = readConfig()
+    const config = await getConfig()
     if (config.api_token) return 'config'
     return null
 }
 
-export function saveConfig(token: string, baseUrl?: string, oauthClientId?: string): void {
-    mkdirSync(CONFIG_DIR, { recursive: true })
-    const existing = readConfig()
+export async function saveConfig(
+    token: string,
+    baseUrl?: string,
+    oauthClientId?: string,
+): Promise<void> {
+    const existing = await getConfig()
     const config: Config = {
         ...existing,
         api_token: token,
@@ -69,11 +54,13 @@ export function saveConfig(token: string, baseUrl?: string, oauthClientId?: stri
     if (oauthClientId) {
         config.oauth_client_id = oauthClientId
     }
-    writeFileSync(CONFIG_PATH, `${JSON.stringify(config, null, 2)}\n`)
+    await setConfig(config)
 }
 
-export function clearConfig(): void {
-    if (existsSync(CONFIG_PATH)) {
-        rmSync(CONFIG_PATH)
+export async function clearConfig(): Promise<void> {
+    try {
+        await unlink(getConfigPath())
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
     }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,4 @@
-import { unlink } from 'node:fs/promises'
-import { type Config, getConfig, getConfigPath, setConfig } from './config.js'
+import { type Config, getConfig, setConfig, updateConfig } from './config.js'
 
 const DEFAULT_BASE_URL = 'https://app.getoutline.com'
 
@@ -43,24 +42,22 @@ export async function saveConfig(
     baseUrl?: string,
     oauthClientId?: string,
 ): Promise<void> {
-    const existing = await getConfig()
-    const config: Config = {
-        ...existing,
-        api_token: token,
-    }
-    if (baseUrl) {
-        config.base_url = baseUrl.replace(/\/$/, '')
-    }
-    if (oauthClientId) {
-        config.oauth_client_id = oauthClientId
-    }
-    await setConfig(config)
+    const updates: Partial<Config> = { api_token: token }
+    if (baseUrl) updates.base_url = baseUrl.replace(/\/$/, '')
+    if (oauthClientId) updates.oauth_client_id = oauthClientId
+    await updateConfig(updates)
 }
 
+/**
+ * Clear the auth-related keys without deleting the file. The config is now
+ * shared with non-auth settings (notably `update_channel`); a blanket unlink
+ * would silently reset the user's update-channel preference too.
+ */
 export async function clearConfig(): Promise<void> {
-    try {
-        await unlink(getConfigPath())
-    } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-    }
+    const existing = await getConfig()
+    const { api_token, base_url, oauth_client_id, ...rest } = existing
+    void api_token
+    void base_url
+    void oauth_client_id
+    await setConfig(rest as Config)
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,34 @@
+import {
+    type CoreConfig,
+    getConfigPath as coreGetConfigPath,
+    readConfig as coreReadConfig,
+    updateConfig as coreUpdateConfig,
+    writeConfig as coreWriteConfig,
+} from '@doist/cli-core'
+
+const APP_NAME = 'outline-cli'
+
+export type Config = CoreConfig & {
+    api_token?: string
+    base_url?: string
+    oauth_client_id?: string
+}
+
+let cachedPath: string | null = null
+
+export function getConfigPath(): string {
+    if (!cachedPath) cachedPath = coreGetConfigPath(APP_NAME)
+    return cachedPath
+}
+
+export async function getConfig(): Promise<Partial<Config>> {
+    return coreReadConfig<Config>(getConfigPath())
+}
+
+export async function setConfig(config: Config): Promise<void> {
+    return coreWriteConfig(getConfigPath(), config)
+}
+
+export async function updateConfig(updates: Partial<Config>): Promise<void> {
+    return coreUpdateConfig<Config>(getConfigPath(), updates)
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -14,11 +14,13 @@ export type Config = CoreConfig & {
     oauth_client_id?: string
 }
 
-let cachedPath: string | null = null
-
+/**
+ * Resolve the canonical config path on every call. Caching at module load
+ * would pin the path to the unmocked `node:os.homedir` before vitest's
+ * `vi.mock('node:os', …)` hoist takes effect in a fresh test file.
+ */
 export function getConfigPath(): string {
-    if (!cachedPath) cachedPath = coreGetConfigPath(APP_NAME)
-    return cachedPath
+    return coreGetConfigPath(APP_NAME)
 }
 
 export async function getConfig(): Promise<Partial<Config>> {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -11,8 +11,6 @@ export type ErrorCode =
     | 'OAUTH_CLIENT_ID_REQUIRED'
     | 'OAUTH_LOGIN_FAILED'
     | 'UNKNOWN_AGENT'
-    // Allow any string while preserving intellisense for known codes.
-    | (string & {})
 
 export class CliError extends CoreCliError<ErrorCode> {
     constructor(

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,28 @@
+import { CliError as CoreCliError, type CliErrorCode, type ErrorType } from '@doist/cli-core'
+
+export type ErrorCode =
+    | 'AUTH_VERIFICATION_FAILED'
+    | 'CONFIRMATION_REQUIRED'
+    | 'CONFLICTING_OPTIONS'
+    | 'INVALID_PARENT'
+    | 'MISSING_OPTION'
+    | 'OAUTH_CALLBACK_PORT_INVALID'
+    | 'OAUTH_CALLBACK_SERVER_FAILED'
+    | 'OAUTH_CLIENT_ID_REQUIRED'
+    | 'OAUTH_LOGIN_FAILED'
+    | 'UNKNOWN_AGENT'
+    // Allow any string while preserving intellisense for known codes.
+    | (string & {})
+
+export class CliError extends CoreCliError<ErrorCode> {
+    constructor(
+        code: ErrorCode | CliErrorCode,
+        message: string,
+        hints?: string[],
+        type: ErrorType = 'error',
+    ) {
+        super(code, message, { hints, type })
+    }
+}
+
+export { getErrorMessage } from '@doist/cli-core'

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,8 +1,16 @@
-import { marked } from 'marked'
-import { markedTerminal } from 'marked-terminal'
+import {
+    preloadMarkdown as corePreloadMarkdown,
+    renderMarkdown as coreRenderMarkdown,
+} from '@doist/cli-core/markdown'
 
-marked.use(markedTerminal())
+let preloadPromise: Promise<void> | null = null
 
-export function renderMarkdown(text: string): string {
-    return marked.parse(text) as string
+export async function preloadMarkdown(): Promise<void> {
+    if (!preloadPromise) preloadPromise = corePreloadMarkdown()
+    return preloadPromise
+}
+
+export async function renderMarkdown(text: string): Promise<string> {
+    await preloadMarkdown()
+    return coreRenderMarkdown(text)
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,3 +1,4 @@
+import { formatJson, formatNdjson } from '@doist/cli-core'
 import chalk from 'chalk'
 import type { Pagination } from './api.js'
 
@@ -23,12 +24,12 @@ export function outputItem<T extends object>(
 ): void {
     if (opts.ndjson) {
         const data = opts.full || !essentialKeys ? item : pick(item, essentialKeys)
-        console.log(JSON.stringify(data))
+        console.log(formatNdjson([data]))
         return
     }
     if (opts.json) {
         const data = opts.full || !essentialKeys ? item : pick(item, essentialKeys)
-        console.log(JSON.stringify(data, null, 2))
+        console.log(formatJson(data))
         return
     }
     console.log(humanFormatter(item))
@@ -42,15 +43,15 @@ export function outputList<T extends object>(
     pagination?: Pagination,
 ): void {
     if (opts.ndjson) {
-        for (const item of items) {
-            const data = opts.full || !essentialKeys ? item : pick(item, essentialKeys)
-            console.log(JSON.stringify(data))
-        }
+        const data = items.map((item) =>
+            opts.full || !essentialKeys ? item : pick(item, essentialKeys),
+        )
+        if (data.length > 0) console.log(formatNdjson(data))
     } else if (opts.json) {
         const data = items.map((item) =>
             opts.full || !essentialKeys ? item : pick(item, essentialKeys),
         )
-        console.log(JSON.stringify(data, null, 2))
+        console.log(formatJson(data))
     } else {
         for (const item of items) {
             console.log(humanFormatter(item))

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -42,16 +42,16 @@ export function outputList<T extends object>(
     opts: OutputOptions = {},
     pagination?: Pagination,
 ): void {
+    const project = (item: T) => (opts.full || !essentialKeys ? item : pick(item, essentialKeys))
+
     if (opts.ndjson) {
-        const data = items.map((item) =>
-            opts.full || !essentialKeys ? item : pick(item, essentialKeys),
-        )
-        if (data.length > 0) console.log(formatNdjson(data))
+        // Stream item-by-item: avoids buffering the whole list and matches
+        // the canonical NDJSON contract (one record per write).
+        for (const item of items) {
+            console.log(formatNdjson([project(item)]))
+        }
     } else if (opts.json) {
-        const data = items.map((item) =>
-            opts.full || !essentialKeys ? item : pick(item, essentialKeys),
-        )
-        console.log(formatJson(data))
+        console.log(formatJson(items.map(project)))
     } else {
         for (const item of items) {
             console.log(humanFormatter(item))

--- a/src/lib/spinner.ts
+++ b/src/lib/spinner.ts
@@ -1,15 +1,10 @@
-import chalk from 'chalk'
-import yoctoSpinner from 'yocto-spinner'
+import { createSpinner } from '@doist/cli-core'
 
-export interface SpinnerOptions {
-    text: string
-    color?: 'green' | 'yellow' | 'blue' | 'red'
-    noSpinner?: boolean
-}
+export type { SpinnerColor, SpinnerOptions } from '@doist/cli-core'
 
 function shouldDisableSpinner(): boolean {
     if (process.env.OL_SPINNER === 'false') return true
-    if (process.env.CI) return true
+    if (process.env.CI && process.env.CI !== 'false') return true
 
     const args = process.argv
     if (args.includes('--json') || args.includes('--ndjson') || args.includes('--no-spinner')) {
@@ -19,54 +14,6 @@ function shouldDisableSpinner(): boolean {
     return false
 }
 
-export class LoadingSpinner {
-    private spinnerInstance: ReturnType<typeof yoctoSpinner> | null = null
+const spinner = createSpinner({ isDisabled: shouldDisableSpinner })
 
-    start(options: SpinnerOptions) {
-        if (!process.stdout.isTTY || options.noSpinner || shouldDisableSpinner()) {
-            return this
-        }
-
-        const colorFn = chalk[options.color || 'blue']
-        this.spinnerInstance = yoctoSpinner({ text: colorFn(options.text) })
-        this.spinnerInstance.start()
-        return this
-    }
-
-    succeed(text?: string) {
-        if (this.spinnerInstance) {
-            this.spinnerInstance.success(text ? chalk.green(`✓ ${text}`) : undefined)
-            this.spinnerInstance = null
-        }
-    }
-
-    fail(text?: string) {
-        if (this.spinnerInstance) {
-            this.spinnerInstance.error(text ? chalk.red(`✗ ${text}`) : undefined)
-            this.spinnerInstance = null
-        }
-    }
-
-    stop() {
-        if (this.spinnerInstance) {
-            this.spinnerInstance.stop()
-            this.spinnerInstance = null
-        }
-    }
-}
-
-export async function withSpinner<T>(
-    options: SpinnerOptions,
-    asyncOperation: () => Promise<T>,
-): Promise<T> {
-    const spinner = new LoadingSpinner().start(options)
-
-    try {
-        const result = await asyncOperation()
-        spinner.stop()
-        return result
-    } catch (error) {
-        spinner.fail()
-        throw error
-    }
-}
+export const { LoadingSpinner, withSpinner, startEarlySpinner, stopEarlySpinner } = spinner

--- a/src/lib/update-config.ts
+++ b/src/lib/update-config.ts
@@ -1,41 +1,12 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { getConfig, updateConfig } from './config.js'
 
 export type UpdateChannel = 'stable' | 'pre-release'
 
-interface UpdateConfig {
-    update_channel?: UpdateChannel
-    [key: string]: unknown
+export async function getUpdateChannel(): Promise<UpdateChannel> {
+    const config = await getConfig()
+    return config.update_channel ?? 'stable'
 }
 
-const CONFIG_DIR = join(homedir(), '.config', 'outline-cli')
-const CONFIG_PATH = join(CONFIG_DIR, 'config.json')
-
-export function getUpdateChannel(): UpdateChannel {
-    if (!existsSync(CONFIG_PATH)) return 'stable'
-    try {
-        const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8')) as UpdateConfig
-        return config.update_channel ?? 'stable'
-    } catch {
-        return 'stable'
-    }
-}
-
-export function setUpdateChannel(channel: UpdateChannel): void {
-    let existing: Record<string, unknown> = {}
-    if (existsSync(CONFIG_PATH)) {
-        try {
-            existing = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8')) as Record<string, unknown>
-        } catch {
-            // ignore
-        }
-    }
-    existing.update_channel = channel
-    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 })
-    writeFileSync(CONFIG_PATH, `${JSON.stringify(existing, null, 2)}\n`, {
-        encoding: 'utf-8',
-        mode: 0o600,
-    })
-    chmodSync(CONFIG_PATH, 0o600)
+export async function setUpdateChannel(channel: UpdateChannel): Promise<void> {
+    await updateConfig({ update_channel: channel })
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+    test: {
+        server: {
+            deps: {
+                inline: ['@doist/cli-core'],
+            },
+        },
+    },
+})


### PR DESCRIPTION
## Summary

First consumer-side integration of [@doist/cli-core](https://www.npmjs.com/package/@doist/cli-core) 0.9.0 into outline-cli. Mirrors twist-cli [#208](https://github.com/Doist/twist-cli/pull/208) (errors / config / spinner / output / markdown helpers) on this codebase. PR 1 of a 3-PR stack:

1. **This PR** — cli-core wiring (errors, config consolidation, spinner, output, markdown)
2. Next — `global-args` + `ViewOptions` + empty-output test helper (mirror of twist-cli #209)
3. Next — delegate `ol update` to `@doist/cli-core/commands` (mirror of twist-cli #214)

The migration step from twist-cli #211 (`updateChannel` → `update_channel`) is not needed: outline-cli already stores the channel under `update_channel`.

## What's wired through cli-core now

| Module | Was | Now |
| --- | --- | --- |
| `src/lib/errors.ts` | n/a (plain `Error`s) | new module — local `CliError` subclass over cli-core's `CliError<ErrorCode>`. Keeps the historical positional `(code, message, hints?, type?)` signature. `code` accepts `ErrorCode \| CliErrorCode` so cli-core's canonical codes type-check at call sites. |
| `src/lib/config.ts` | n/a — config reads were split across `auth.ts` (api_token / base_url / oauth_client_id) and `update-config.ts` (update_channel), both writing the same file with their own sync `fs` calls | new module — thin wrappers over cli-core's `readConfig` / `writeConfig` / `updateConfig` with `'outline-cli'` app name. Single source of truth for the config schema. |
| `src/lib/auth.ts` | sync `fs` reads + writes, racing `update-config.ts` on the same file | async wrappers over `config.ts`. Public API preserved (`getApiToken` / `getBaseUrl` / `getOAuthClientId` / `getTokenSource` / `saveConfig` / `clearConfig`) — now returns promises. |
| `src/lib/update-config.ts` | independent sync `fs` reader/writer hitting the same config file | async wrappers over `config.ts`. |
| `src/lib/spinner.ts` | local 70-line impl with yocto-spinner, manual `chalk.green('✓ …')` / `chalk.red('✗ …')` doubling, ad-hoc `shouldDisableSpinner` | `const spinner = createSpinner({ isDisabled: shouldDisableSpinner })` + destructured exports. The CLI-specific bit (`OL_SPINNER` opt-out + `--json` / `--ndjson` / `--no-spinner` fan-out, `CI` opt-out aware: `CI='false'` is treated as not-CI) is wired in as `isDisabled`. |
| `src/lib/output.ts` | inline `JSON.stringify(_, null, 2)` / one log per ndjson item | delegates serialization to cli-core's `formatJson` / `formatNdjson`. `formatError` and the essential-keys filtering layer stay local. |
| `src/lib/markdown.ts` | `marked@15` + `marked-terminal@7` with sync `marked.parse()` | cli-core's `preloadMarkdown` / `renderMarkdown` (async). `renderMarkdown` call site in `document.ts` now awaits. |

## Dependency bumps

- Add `@doist/cli-core` 0.9.0
- `marked` 15.0.12 → 18.0.3 (cli-core peer requires `>=18`)
- Replace `marked-terminal` 7.3.0 (caps at `marked@<16`) with `marked-terminal-renderer` 2.2.0 — same fork that cli-core itself uses, no marked version cap
- Drop `yocto-spinner` from direct deps (still resolved transitively via cli-core)
- `vitest` 4.0.18 → 4.1.5 (cli-core peer requires `>=4.1`)

## Behaviour changes worth flagging

- `yocto-spinner.success()` and `.error()` already prepend their own `✔` / `✖` glyphs. The old `spinner.ts` added a manual `chalk.green('✓ ')` / `chalk.red('✗ ')` on top, which produced doubled symbols in real terminals (e.g. `✔ ✓ Done`). cli-core 0.3+ drops the manual prefixes — so the success / fail line now renders as a single `✔ Done` instead of `✔ ✓ Done`.
- `updateConfig` now uses cli-core's strict-read semantics: a broken config file throws instead of being silently overwritten (the previous lenient `getUpdateChannel` + `setUpdateChannel` composition could clobber data the user might have recovered by hand-fixing the file).
- `auth.ts` and `update-config.ts` no longer race on writes — both go through the single `config.ts` wrapper.
- `CI='false'` is now honoured as an opt-out (the spinner runs).

## vitest config

Adds `server.deps.inline: ['@doist/cli-core']` to a new `vitest.config.ts`. Without it, vitest treats the real-installed cli-core as external and `vi.mock('@doist/cli-core', …)` doesn't reach its compiled imports.

## Tests

- `src/__tests__/spinner.test.ts` trimmed to a single smoke test that mocks `@doist/cli-core#createSpinner` and asserts the kit is built with a function `isDisabled`. The previous ~200 lines of behavioural coverage now live in cli-core's own spinner suite.
- `src/__tests__/auth.test.ts` updated for the async API; same coverage.
- `src/__tests__/output.test.ts` adjusts the ndjson expectation to match cli-core's `formatNdjson` (single `console.log` with `\n`-joined entries rather than one log per item).
- `src/__tests__/commands.test.ts` mocks `auth.js` with async functions; the document-get rendering assertion drops the `# ` prefix (marked-terminal-renderer renders headings differently from the old marked-terminal).

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint:check` — 0 warnings, 0 errors
- [x] `npm test` — **118 / 118** pass
- [x] `npm run build`
- [x] `npm run check:skill-sync`
- [x] `npm ls yocto-spinner` confirms cli-core still resolves it transitively
- [ ] Manually exercise `ol auth status`, `ol auth login`, `ol update --channel` against a real config
- [ ] Run a long-running command (`ol search foo`) in a TTY to confirm the spinner appears and **no doubled `✔ ✓` glyphs** on success
- [ ] `CI=1 ol search foo`, `ol search foo --json`, `OL_SPINNER=false ol search foo` to confirm spinner suppression

🤖 Generated with [Claude Code](https://claude.com/claude-code)