### PR TITLE
feat(account): account command group (cli-core attachers)

### DIFF
--- a/skills/outline-cli/SKILL.md
+++ b/skills/outline-cli/SKILL.md
@@ -15,6 +15,7 @@ Use this skill when the user wants to interact with their Outline wiki/knowledge
 - `ol doc open <id>` - Open document in browser
 - `ol doc create --title "Title" --collection <id>` - Create document
 - `ol col list` - List collections
+- `ol account` - List stored accounts; `ol account use <id|name>` sets the default
 
 ## Output Formats
 
@@ -87,6 +88,19 @@ ol auth status                         # Show current auth state
 ol auth status --json | --ndjson       # Machine-readable status envelope ({id, team, baseUrl, source})
 ol auth logout                         # Clear saved credentials
 ol auth logout --json | --ndjson       # Machine-readable logout envelope ({ok: true}; --ndjson is silent)
+```
+
+### Accounts
+```bash
+ol account                             # List stored accounts (default subcommand)
+ol account list                        # List stored accounts, default marked
+ol account list --json | --ndjson      # Machine-readable list ({accounts, default}; --ndjson streams one per line)
+ol account current                     # Show the active account (honours --user and OUTLINE_API_TOKEN)
+ol account current --json | --ndjson   # Machine-readable active account ({id, label, teamName, baseUrl, isDefault})
+ol account use <id|name>               # Set the default account used when --user is omitted
+ol account use <id|name> --json        # Machine-readable envelope ({ok: true, default: <id>}; --ndjson is silent)
+ol account remove <id|name>            # Remove a stored account (clears keyring + config entry)
+ol account remove <id|name> --json     # Machine-readable envelope ({ok: true, removed: <id>}; --ndjson is silent)
 ```
 
 ### Update & Changelog

--- a/skills/outline-cli/SKILL.md
+++ b/skills/outline-cli/SKILL.md
@@ -96,7 +96,7 @@ ol account                             # List stored accounts (default subcomman
 ol account list                        # List stored accounts, default marked
 ol account list --json | --ndjson      # Machine-readable list ({accounts, default}; --ndjson streams one per line)
 ol account current                     # Show the active account (honours --user and OUTLINE_API_TOKEN)
-ol account current --json | --ndjson   # Machine-readable active account ({id, label, teamName, baseUrl, isDefault})
+ol account current --json | --ndjson   # Discriminated by source: {source:"stored", account:{id, label, teamName, baseUrl, isDefault}} | {source:"env"} | {source:"legacy"}
 ol account use <id|name>               # Set the default account used when --user is omitted
 ol account use <id|name> --json        # Machine-readable envelope ({ok: true, default: <id>}; --ndjson is silent)
 ol account remove <id|name>            # Remove a stored account (clears keyring + config entry)

--- a/src/_fixtures/auth.ts
+++ b/src/_fixtures/auth.ts
@@ -11,6 +11,15 @@ export const STORED_ACCOUNT: OutlineAccount = {
     teamName: 'Analytics',
 }
 
+/** Secondary persisted `OutlineAccount` on a different instance — for multi-account tests. */
+export const STORED_ACCOUNT_BOB: OutlineAccount = {
+    id: 'bob-uuid',
+    label: 'Bob',
+    baseUrl: 'https://bob.example.com',
+    oauthClientId: 'cid-bob',
+    teamName: 'Engineering',
+}
+
 /** v1 plaintext config snapshot that round-trips to `STORED_ACCOUNT`. */
 export const LEGACY_CONFIG = {
     api_token: 'tk_legacy_plaintext',

--- a/src/commands/account.test.ts
+++ b/src/commands/account.test.ts
@@ -2,60 +2,31 @@ import { captureConsole, createTestProgram } from '@doist/cli-core/testing'
 import type { Command } from 'commander'
 import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { STORED_ACCOUNT, STORED_ACCOUNT_BOB } from '../_fixtures/auth.js'
-import type { OutlineAccount } from '../lib/outline-account.js'
-import { matchOutlineAccount } from '../lib/outline-account.js'
+import { CliError } from '../lib/errors.js'
 
-// In-memory stand-in for the keyring store. `setDefault` / `clear` resolve the
-// raw `<ref>` through the real `matchOutlineAccount` (id or display name), so
-// the cli-core attachers run against a realistic store and exercise the actual
-// ref-matching + default-resolution wiring this command adds — not just a stub.
+// `account` consumes two auth-provider exports: the token store (list/use/remove
+// drive its `list`/`setDefault`/`clear`) and `resolveActiveAccountSource` (which
+// `current` uses to classify the active credential). Both are stubbed per-test —
+// the source-precedence logic itself is covered in auth-provider.test.ts.
 const storeMocks = vi.hoisted(() => ({
     list: vi.fn(),
     setDefault: vi.fn(),
     clear: vi.fn(),
-    active: vi.fn(),
-    activeBundle: vi.fn(),
-    activeAccount: vi.fn(),
-    set: vi.fn(),
-    setBundle: vi.fn(),
-    getLastStorageResult: vi.fn(),
     getLastClearResult: vi.fn(() => undefined),
 }))
+const resolveMock = vi.hoisted(() => vi.fn())
 
 vi.mock('../lib/auth-provider.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../lib/auth-provider.js')>()
-    return { ...actual, createOutlineTokenStore: () => storeMocks }
+    return {
+        ...actual,
+        createOutlineTokenStore: () => storeMocks,
+        resolveActiveAccountSource: resolveMock,
+    }
 })
 
 function lines(spy: MockInstance): string {
     return spy.mock.calls.map((args) => args.join(' ')).join('\n')
-}
-
-function seedStore(...records: Array<OutlineAccount | [OutlineAccount, 'default']>): void {
-    const list = records.map((spec) =>
-        Array.isArray(spec)
-            ? { account: spec[0], isDefault: true }
-            : { account: spec, isDefault: false },
-    )
-    storeMocks.list.mockResolvedValue(list)
-    storeMocks.activeAccount.mockImplementation(async (ref?: string) => {
-        if (ref === undefined) return list.find((entry) => entry.isDefault) ?? null
-        return list.find((entry) => matchOutlineAccount(entry.account, ref)) ?? null
-    })
-    storeMocks.setDefault.mockImplementation(async (ref: string) => {
-        const match = list.find((entry) => matchOutlineAccount(entry.account, ref))
-        if (!match) {
-            const { CliError } = await import('../lib/errors.js')
-            throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${ref}".`)
-        }
-        for (const entry of list) entry.isDefault = entry === match
-    })
-    storeMocks.clear.mockImplementation(async (ref: string) => {
-        const index = list.findIndex((entry) => matchOutlineAccount(entry.account, ref))
-        if (index < 0) return null
-        const [removed] = list.splice(index, 1)
-        return { account: removed.account, wasDefault: removed.isDefault }
-    })
 }
 
 async function buildProgram(): Promise<Command> {
@@ -84,7 +55,10 @@ afterEach(() => {
 describe('account command', () => {
     describe('list', () => {
         it('renders all stored accounts with the default marker', async () => {
-            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            storeMocks.list.mockResolvedValue([
+                { account: STORED_ACCOUNT, isDefault: true },
+                { account: STORED_ACCOUNT_BOB, isDefault: false },
+            ])
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'list'])
             const out = lines(logSpy)
@@ -95,21 +69,24 @@ describe('account command', () => {
         })
 
         it('prints the empty-state message when nothing is stored', async () => {
-            seedStore()
+            storeMocks.list.mockResolvedValue([])
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'list'])
             expect(lines(logSpy)).toMatch(/No stored accounts/)
         })
 
         it('runs by default when no subcommand is given (ol account)', async () => {
-            seedStore([STORED_ACCOUNT, 'default'])
+            storeMocks.list.mockResolvedValue([{ account: STORED_ACCOUNT, isDefault: true }])
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account'])
             expect(lines(logSpy)).toContain('Ada')
         })
 
         it('emits a {accounts, default} envelope under --json', async () => {
-            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            storeMocks.list.mockResolvedValue([
+                { account: STORED_ACCOUNT, isDefault: true },
+                { account: STORED_ACCOUNT_BOB, isDefault: false },
+            ])
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'list', '--json'])
             const payload = JSON.parse(lines(logSpy))
@@ -123,25 +100,28 @@ describe('account command', () => {
 
     describe('use', () => {
         it('sets the default account and echoes the ref', async () => {
-            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            storeMocks.setDefault.mockResolvedValue(undefined)
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'use', STORED_ACCOUNT_BOB.id])
             expect(storeMocks.setDefault).toHaveBeenCalledWith(STORED_ACCOUNT_BOB.id)
             expect(lines(logSpy)).toContain(`Default account set to ${STORED_ACCOUNT_BOB.id}`)
         })
 
-        it('propagates ACCOUNT_NOT_FOUND for an unknown ref', async () => {
-            seedStore([STORED_ACCOUNT, 'default'])
+        it('propagates ACCOUNT_NOT_FOUND from setDefault for an unknown ref', async () => {
+            storeMocks.setDefault.mockRejectedValue(
+                new CliError('ACCOUNT_NOT_FOUND', 'No stored account matches "nobody".'),
+            )
             const program = await buildProgram()
             await expect(
                 program.parseAsync(['node', 'ol', 'account', 'use', 'nobody']),
             ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
+            expect(storeMocks.setDefault).toHaveBeenCalledWith('nobody')
         })
     })
 
     describe('remove', () => {
-        it('clears the account by display name and prints the removed label', async () => {
-            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+        it('clears the account by the raw ref and prints the removed label', async () => {
+            storeMocks.clear.mockResolvedValue({ account: STORED_ACCOUNT_BOB, wasDefault: false })
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'remove', 'bob'])
             expect(storeMocks.clear).toHaveBeenCalledWith('bob')
@@ -149,7 +129,7 @@ describe('account command', () => {
         })
 
         it('notes a cleared default when removing the default account', async () => {
-            seedStore([STORED_ACCOUNT, 'default'])
+            storeMocks.clear.mockResolvedValue({ account: STORED_ACCOUNT, wasDefault: true })
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'remove', STORED_ACCOUNT.id])
             const out = lines(logSpy)
@@ -157,8 +137,16 @@ describe('account command', () => {
             expect(out).toMatch(/Cleared default account/)
         })
 
+        it('throws ACCOUNT_NOT_FOUND when clear matches nothing', async () => {
+            storeMocks.clear.mockResolvedValue(null)
+            const program = await buildProgram()
+            await expect(
+                program.parseAsync(['node', 'ol', 'account', 'remove', 'ghost']),
+            ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
+        })
+
         it('surfaces a keyring-fallback warning on stderr', async () => {
-            seedStore([STORED_ACCOUNT, 'default'])
+            storeMocks.clear.mockResolvedValue({ account: STORED_ACCOUNT, wasDefault: true })
             storeMocks.getLastClearResult.mockReturnValue({
                 storage: 'config-file',
                 warning: 'OS keyring unavailable; cleared the config-file token instead.',
@@ -171,7 +159,11 @@ describe('account command', () => {
 
     describe('current', () => {
         it('renders the active stored account', async () => {
-            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            resolveMock.mockResolvedValue({
+                source: 'stored',
+                account: STORED_ACCOUNT,
+                isDefault: true,
+            })
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'current'])
             const out = lines(logSpy)
@@ -180,7 +172,11 @@ describe('account command', () => {
         })
 
         it('emits a {source:"stored", account} envelope under --json', async () => {
-            seedStore([STORED_ACCOUNT, 'default'])
+            resolveMock.mockResolvedValue({
+                source: 'stored',
+                account: STORED_ACCOUNT,
+                isDefault: true,
+            })
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'current', '--json'])
             const payload = JSON.parse(lines(logSpy))
@@ -189,58 +185,63 @@ describe('account command', () => {
             expect(payload.account).not.toHaveProperty('oauthClientId')
         })
 
-        it('honours --user, bypassing an env token to show the requested account', async () => {
-            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+        it('threads --user through to the source resolver, bypassing an env token', async () => {
             process.env.OUTLINE_API_TOKEN = 'tok-env'
             // The root `--user` is stripped from argv before commander in the real
             // flow; the global-args parser still reads it off the original argv.
             process.argv = ['node', 'ol', '--user', 'Bob', 'account', 'current']
+            resolveMock.mockImplementation(async (ref?: string) =>
+                ref === 'Bob'
+                    ? { source: 'stored', account: STORED_ACCOUNT_BOB, isDefault: false }
+                    : { source: 'env' },
+            )
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'current'])
+            expect(resolveMock).toHaveBeenCalledWith('Bob')
             const out = lines(logSpy)
             expect(out).toContain('Bob')
             expect(out).not.toContain('OUTLINE_API_TOKEN')
         })
 
-        it('reports the env-token source when OUTLINE_API_TOKEN is set', async () => {
-            seedStore([STORED_ACCOUNT, 'default'])
-            process.env.OUTLINE_API_TOKEN = 'tok-env'
-            const program = await buildProgram()
-            await program.parseAsync(['node', 'ol', 'account', 'current'])
+        it('reports the env-token source (human + --json)', async () => {
+            resolveMock.mockResolvedValue({ source: 'env' })
+            await (await buildProgram()).parseAsync(['node', 'ol', 'account', 'current'])
             expect(lines(logSpy)).toContain('OUTLINE_API_TOKEN')
-            // Env wins before any stored-account resolution is attempted.
-            expect(storeMocks.activeAccount).not.toHaveBeenCalled()
+
+            logSpy.mockClear()
+            resolveMock.mockResolvedValue({ source: 'env' })
+            await (await buildProgram()).parseAsync(['node', 'ol', 'account', 'current', '--json'])
+            expect(JSON.parse(lines(logSpy))).toEqual({ source: 'env' })
         })
 
-        it('prefers a stored default over a lingering legacy token', async () => {
-            // Store resolves a v2 default; a legacy snapshot also exists (its
-            // account is absent from list()). The stored account must win.
-            seedStore([STORED_ACCOUNT, 'default'])
-            const program = await buildProgram()
-            await program.parseAsync(['node', 'ol', 'account', 'current'])
-            expect(lines(logSpy)).toContain('Ada')
-            expect(lines(logSpy)).not.toMatch(/legacy/)
-        })
-
-        it('reports the legacy source when only a legacy snapshot resolves', async () => {
-            // No v2 records, but the store still resolves a legacy single-user
-            // snapshot (not present in list()).
-            storeMocks.list.mockResolvedValue([])
-            storeMocks.activeAccount.mockResolvedValue({
-                account: STORED_ACCOUNT,
-                isDefault: true,
-            })
-            const program = await buildProgram()
-            await program.parseAsync(['node', 'ol', 'account', 'current'])
+        it('reports the legacy source (human + --json)', async () => {
+            resolveMock.mockResolvedValue({ source: 'legacy' })
+            await (await buildProgram()).parseAsync(['node', 'ol', 'account', 'current'])
             expect(lines(logSpy)).toMatch(/legacy single-user credentials/)
+
+            logSpy.mockClear()
+            resolveMock.mockResolvedValue({ source: 'legacy' })
+            await (
+                await buildProgram()
+            ).parseAsync(['node', 'ol', 'account', 'current', '--ndjson'])
+            expect(JSON.parse(lines(logSpy))).toEqual({ source: 'legacy' })
         })
 
         it('throws NOT_AUTHENTICATED when nothing is active', async () => {
-            seedStore()
+            resolveMock.mockResolvedValue(null)
             const program = await buildProgram()
             await expect(
                 program.parseAsync(['node', 'ol', 'account', 'current']),
             ).rejects.toHaveProperty('code', 'NOT_AUTHENTICATED')
+        })
+
+        it('throws ACCOUNT_NOT_FOUND when an explicit --user matches nothing', async () => {
+            process.argv = ['node', 'ol', '--user', 'Ghost', 'account', 'current']
+            resolveMock.mockResolvedValue(null)
+            const program = await buildProgram()
+            await expect(
+                program.parseAsync(['node', 'ol', 'account', 'current']),
+            ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
         })
     })
 })

--- a/src/commands/account.test.ts
+++ b/src/commands/account.test.ts
@@ -5,9 +5,10 @@ import { STORED_ACCOUNT, STORED_ACCOUNT_BOB } from '../_fixtures/auth.js'
 import type { OutlineAccount } from '../lib/outline-account.js'
 import { matchOutlineAccount } from '../lib/outline-account.js'
 
-// In-memory stand-in for the keyring store: `setDefault` / `clear` resolve the
+// In-memory stand-in for the keyring store. `setDefault` / `clear` resolve the
 // raw `<ref>` through the real `matchOutlineAccount` (id or display name), so
-// ref-matching is exercised rather than stubbed.
+// the cli-core attachers run against a realistic store and exercise the actual
+// ref-matching + default-resolution wiring this command adds — not just a stub.
 const storeMocks = vi.hoisted(() => ({
     list: vi.fn(),
     setDefault: vi.fn(),
@@ -21,15 +22,9 @@ const storeMocks = vi.hoisted(() => ({
     getLastClearResult: vi.fn(() => undefined),
 }))
 
-const legacyMock = vi.hoisted(() => ({ isLegacyAuthActive: vi.fn(async () => false) }))
-
 vi.mock('../lib/auth-provider.js', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../lib/auth-provider.js')>()
-    return {
-        ...actual,
-        createOutlineTokenStore: () => storeMocks,
-        isLegacyAuthActive: legacyMock.isLegacyAuthActive,
-    }
+    return { ...actual, createOutlineTokenStore: () => storeMocks }
 })
 
 function lines(spy: MockInstance): string {
@@ -69,11 +64,13 @@ async function buildProgram(): Promise<Command> {
 }
 
 let logSpy: MockInstance
+let errSpy: MockInstance
 
 beforeEach(() => {
     vi.resetModules()
     delete process.env.OUTLINE_API_TOKEN
     logSpy = captureConsole('log')
+    errSpy = captureConsole('error')
 })
 
 afterEach(() => {
@@ -159,6 +156,17 @@ describe('account command', () => {
             expect(out).toContain('Removed Ada')
             expect(out).toMatch(/Cleared default account/)
         })
+
+        it('surfaces a keyring-fallback warning on stderr', async () => {
+            seedStore([STORED_ACCOUNT, 'default'])
+            storeMocks.getLastClearResult.mockReturnValue({
+                storage: 'config-file',
+                warning: 'OS keyring unavailable; cleared the config-file token instead.',
+            })
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'remove', STORED_ACCOUNT.id])
+            expect(lines(errSpy)).toContain('OS keyring unavailable')
+        })
     })
 
     describe('current', () => {
@@ -171,18 +179,57 @@ describe('account command', () => {
             expect(out).toContain(STORED_ACCOUNT.baseUrl)
         })
 
+        it('emits a {source:"stored", account} envelope under --json', async () => {
+            seedStore([STORED_ACCOUNT, 'default'])
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'current', '--json'])
+            const payload = JSON.parse(lines(logSpy))
+            expect(payload.source).toBe('stored')
+            expect(payload.account).toMatchObject({ id: STORED_ACCOUNT.id, isDefault: true })
+            expect(payload.account).not.toHaveProperty('oauthClientId')
+        })
+
+        it('honours --user, bypassing an env token to show the requested account', async () => {
+            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            process.env.OUTLINE_API_TOKEN = 'tok-env'
+            // The root `--user` is stripped from argv before commander in the real
+            // flow; the global-args parser still reads it off the original argv.
+            process.argv = ['node', 'ol', '--user', 'Bob', 'account', 'current']
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'current'])
+            const out = lines(logSpy)
+            expect(out).toContain('Bob')
+            expect(out).not.toContain('OUTLINE_API_TOKEN')
+        })
+
         it('reports the env-token source when OUTLINE_API_TOKEN is set', async () => {
             seedStore([STORED_ACCOUNT, 'default'])
             process.env.OUTLINE_API_TOKEN = 'tok-env'
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'current'])
             expect(lines(logSpy)).toContain('OUTLINE_API_TOKEN')
+            // Env wins before any stored-account resolution is attempted.
             expect(storeMocks.activeAccount).not.toHaveBeenCalled()
         })
 
-        it('reports the legacy source when a legacy session is active', async () => {
-            seedStore()
-            legacyMock.isLegacyAuthActive.mockResolvedValue(true)
+        it('prefers a stored default over a lingering legacy token', async () => {
+            // Store resolves a v2 default; a legacy snapshot also exists (its
+            // account is absent from list()). The stored account must win.
+            seedStore([STORED_ACCOUNT, 'default'])
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'current'])
+            expect(lines(logSpy)).toContain('Ada')
+            expect(lines(logSpy)).not.toMatch(/legacy/)
+        })
+
+        it('reports the legacy source when only a legacy snapshot resolves', async () => {
+            // No v2 records, but the store still resolves a legacy single-user
+            // snapshot (not present in list()).
+            storeMocks.list.mockResolvedValue([])
+            storeMocks.activeAccount.mockResolvedValue({
+                account: STORED_ACCOUNT,
+                isDefault: true,
+            })
             const program = await buildProgram()
             await program.parseAsync(['node', 'ol', 'account', 'current'])
             expect(lines(logSpy)).toMatch(/legacy single-user credentials/)
@@ -190,7 +237,6 @@ describe('account command', () => {
 
         it('throws NOT_AUTHENTICATED when nothing is active', async () => {
             seedStore()
-            legacyMock.isLegacyAuthActive.mockResolvedValue(false)
             const program = await buildProgram()
             await expect(
                 program.parseAsync(['node', 'ol', 'account', 'current']),

--- a/src/commands/account.test.ts
+++ b/src/commands/account.test.ts
@@ -1,0 +1,200 @@
+import { captureConsole, createTestProgram } from '@doist/cli-core/testing'
+import type { Command } from 'commander'
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { STORED_ACCOUNT, STORED_ACCOUNT_BOB } from '../_fixtures/auth.js'
+import type { OutlineAccount } from '../lib/outline-account.js'
+import { matchOutlineAccount } from '../lib/outline-account.js'
+
+// In-memory stand-in for the keyring store: `setDefault` / `clear` resolve the
+// raw `<ref>` through the real `matchOutlineAccount` (id or display name), so
+// ref-matching is exercised rather than stubbed.
+const storeMocks = vi.hoisted(() => ({
+    list: vi.fn(),
+    setDefault: vi.fn(),
+    clear: vi.fn(),
+    active: vi.fn(),
+    activeBundle: vi.fn(),
+    activeAccount: vi.fn(),
+    set: vi.fn(),
+    setBundle: vi.fn(),
+    getLastStorageResult: vi.fn(),
+    getLastClearResult: vi.fn(() => undefined),
+}))
+
+const legacyMock = vi.hoisted(() => ({ isLegacyAuthActive: vi.fn(async () => false) }))
+
+vi.mock('../lib/auth-provider.js', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../lib/auth-provider.js')>()
+    return {
+        ...actual,
+        createOutlineTokenStore: () => storeMocks,
+        isLegacyAuthActive: legacyMock.isLegacyAuthActive,
+    }
+})
+
+function lines(spy: MockInstance): string {
+    return spy.mock.calls.map((args) => args.join(' ')).join('\n')
+}
+
+function seedStore(...records: Array<OutlineAccount | [OutlineAccount, 'default']>): void {
+    const list = records.map((spec) =>
+        Array.isArray(spec)
+            ? { account: spec[0], isDefault: true }
+            : { account: spec, isDefault: false },
+    )
+    storeMocks.list.mockResolvedValue(list)
+    storeMocks.activeAccount.mockImplementation(async (ref?: string) => {
+        if (ref === undefined) return list.find((entry) => entry.isDefault) ?? null
+        return list.find((entry) => matchOutlineAccount(entry.account, ref)) ?? null
+    })
+    storeMocks.setDefault.mockImplementation(async (ref: string) => {
+        const match = list.find((entry) => matchOutlineAccount(entry.account, ref))
+        if (!match) {
+            const { CliError } = await import('../lib/errors.js')
+            throw new CliError('ACCOUNT_NOT_FOUND', `No stored account matches "${ref}".`)
+        }
+        for (const entry of list) entry.isDefault = entry === match
+    })
+    storeMocks.clear.mockImplementation(async (ref: string) => {
+        const index = list.findIndex((entry) => matchOutlineAccount(entry.account, ref))
+        if (index < 0) return null
+        const [removed] = list.splice(index, 1)
+        return { account: removed.account, wasDefault: removed.isDefault }
+    })
+}
+
+async function buildProgram(): Promise<Command> {
+    const { registerAccountCommand } = await import('./account.js')
+    return createTestProgram(registerAccountCommand)
+}
+
+let logSpy: MockInstance
+
+beforeEach(() => {
+    vi.resetModules()
+    delete process.env.OUTLINE_API_TOKEN
+    logSpy = captureConsole('log')
+})
+
+afterEach(() => {
+    vi.clearAllMocks()
+    delete process.env.OUTLINE_API_TOKEN
+    // Reset argv so a `--user` set by one test can't leak into the next via the
+    // (real) global-args parser.
+    process.argv = ['node', 'ol']
+})
+
+describe('account command', () => {
+    describe('list', () => {
+        it('renders all stored accounts with the default marker', async () => {
+            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'list'])
+            const out = lines(logSpy)
+            expect(out).toContain('Ada')
+            expect(out).toContain('Bob')
+            expect(out).toContain(`id:${STORED_ACCOUNT.id}`)
+            expect(out).toMatch(/default/)
+        })
+
+        it('prints the empty-state message when nothing is stored', async () => {
+            seedStore()
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'list'])
+            expect(lines(logSpy)).toMatch(/No stored accounts/)
+        })
+
+        it('runs by default when no subcommand is given (ol account)', async () => {
+            seedStore([STORED_ACCOUNT, 'default'])
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account'])
+            expect(lines(logSpy)).toContain('Ada')
+        })
+
+        it('emits a {accounts, default} envelope under --json', async () => {
+            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'list', '--json'])
+            const payload = JSON.parse(lines(logSpy))
+            expect(payload.default).toBe(STORED_ACCOUNT.id)
+            expect(payload.accounts).toHaveLength(2)
+            expect(payload.accounts[0]).toMatchObject({ id: STORED_ACCOUNT.id, isDefault: true })
+            // The OAuth client id is intentionally dropped from machine output.
+            expect(payload.accounts[0]).not.toHaveProperty('oauthClientId')
+        })
+    })
+
+    describe('use', () => {
+        it('sets the default account and echoes the ref', async () => {
+            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'use', STORED_ACCOUNT_BOB.id])
+            expect(storeMocks.setDefault).toHaveBeenCalledWith(STORED_ACCOUNT_BOB.id)
+            expect(lines(logSpy)).toContain(`Default account set to ${STORED_ACCOUNT_BOB.id}`)
+        })
+
+        it('propagates ACCOUNT_NOT_FOUND for an unknown ref', async () => {
+            seedStore([STORED_ACCOUNT, 'default'])
+            const program = await buildProgram()
+            await expect(
+                program.parseAsync(['node', 'ol', 'account', 'use', 'nobody']),
+            ).rejects.toHaveProperty('code', 'ACCOUNT_NOT_FOUND')
+        })
+    })
+
+    describe('remove', () => {
+        it('clears the account by display name and prints the removed label', async () => {
+            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'remove', 'bob'])
+            expect(storeMocks.clear).toHaveBeenCalledWith('bob')
+            expect(lines(logSpy)).toContain('Removed Bob')
+        })
+
+        it('notes a cleared default when removing the default account', async () => {
+            seedStore([STORED_ACCOUNT, 'default'])
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'remove', STORED_ACCOUNT.id])
+            const out = lines(logSpy)
+            expect(out).toContain('Removed Ada')
+            expect(out).toMatch(/Cleared default account/)
+        })
+    })
+
+    describe('current', () => {
+        it('renders the active stored account', async () => {
+            seedStore([STORED_ACCOUNT, 'default'], STORED_ACCOUNT_BOB)
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'current'])
+            const out = lines(logSpy)
+            expect(out).toContain('Ada')
+            expect(out).toContain(STORED_ACCOUNT.baseUrl)
+        })
+
+        it('reports the env-token source when OUTLINE_API_TOKEN is set', async () => {
+            seedStore([STORED_ACCOUNT, 'default'])
+            process.env.OUTLINE_API_TOKEN = 'tok-env'
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'current'])
+            expect(lines(logSpy)).toContain('OUTLINE_API_TOKEN')
+            expect(storeMocks.activeAccount).not.toHaveBeenCalled()
+        })
+
+        it('reports the legacy source when a legacy session is active', async () => {
+            seedStore()
+            legacyMock.isLegacyAuthActive.mockResolvedValue(true)
+            const program = await buildProgram()
+            await program.parseAsync(['node', 'ol', 'account', 'current'])
+            expect(lines(logSpy)).toMatch(/legacy single-user credentials/)
+        })
+
+        it('throws NOT_AUTHENTICATED when nothing is active', async () => {
+            seedStore()
+            legacyMock.isLegacyAuthActive.mockResolvedValue(false)
+            const program = await buildProgram()
+            await expect(
+                program.parseAsync(['node', 'ol', 'account', 'current']),
+            ).rejects.toHaveProperty('code', 'NOT_AUTHENTICATED')
+        })
+    })
+})

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -1,7 +1,5 @@
 import { emitView } from '@doist/cli-core'
 import {
-    type AccountRef,
-    attachAccountCurrentCommand,
     attachAccountListCommand,
     attachAccountRemoveCommand,
     attachAccountUseCommand,
@@ -13,7 +11,6 @@ import { logClearResult } from '../lib/auth-output.js'
 import {
     createOutlineTokenStore,
     type OutlineAccount,
-    type OutlineTokenStore,
     resolveActiveAccountSource,
 } from '../lib/auth-provider.js'
 import { CliError } from '../lib/errors.js'
@@ -34,45 +31,6 @@ function projectAccount(account: OutlineAccount, isDefault: boolean) {
         baseUrl: account.baseUrl,
         isDefault,
     }
-}
-
-/**
- * Adapt the authoritative `resolveActiveAccountSource` to the `activeAccount`
- * contract cli-core's `current` attacher consumes: a stored account resolves
- * normally; the out-of-store env/legacy sources resolve to `null` (their source
- * stashed for `onNotAuthenticated` to render) so they aren't shown as accounts.
- * A `--user`/positional ref that matches nothing surfaces as `ACCOUNT_NOT_FOUND`,
- * matching the global `--user` selector elsewhere.
- */
-function currentResolverStore(store: OutlineTokenStore): {
-    store: OutlineTokenStore
-    getSource: () => 'env' | 'legacy' | undefined
-} {
-    let source: 'env' | 'legacy' | undefined
-    const wrapped: OutlineTokenStore = {
-        ...store,
-        activeAccount: async (ref?: AccountRef) => {
-            source = undefined
-            const requested = ref ?? getRequestedUserRef()
-            const resolution = await resolveActiveAccountSource(requested)
-            if (resolution?.source === 'stored') {
-                return { account: resolution.account, isDefault: resolution.isDefault }
-            }
-            if (resolution) {
-                source = resolution.source
-                return null
-            }
-            if (requested !== undefined) {
-                throw new CliError(
-                    'ACCOUNT_NOT_FOUND',
-                    `No stored account matches "${requested}".`,
-                    ['Check the account id or display name, or run `ol auth login` to add it.'],
-                )
-            }
-            return null
-        },
-    }
-    return { store: wrapped, getSource: () => source }
 }
 
 export function registerAccountCommand(program: Command): void {
@@ -96,36 +54,52 @@ export function registerAccountCommand(program: Command): void {
         description: 'Set the default account (matched by Outline user id or display name)',
     })
 
-    const { store: currentStore, getSource } = currentResolverStore(store)
-    attachAccountCurrentCommand<OutlineAccount>(account, {
-        store: currentStore,
-        description: 'Show the active account (honours --user and OUTLINE_API_TOKEN)',
-        renderText: ({ account, isDefault }) => {
-            const lines = [accountLine(account, isDefault), `  Base URL: ${account.baseUrl}`]
-            if (account.teamName) lines.push(`  Team: ${account.teamName}`)
-            return lines
-        },
-        renderJson: ({ account, isDefault }) => ({
-            source: 'stored',
-            account: projectAccount(account, isDefault),
-        }),
-        onNotAuthenticated({ view }) {
-            const source = getSource()
-            if (source === 'env') {
+    // `current` resolves the active credential's source directly (env / stored /
+    // legacy) rather than going through the generic account attacher, which only
+    // models stored accounts. `--json` / `--ndjson` emit a discriminated envelope.
+    account
+        .command('current')
+        .description('Show the active account (honours --user and OUTLINE_API_TOKEN)')
+        .option('--json', 'Emit machine-readable JSON output')
+        .option('--ndjson', 'Emit machine-readable NDJSON output')
+        .action(async (options: { json?: boolean; ndjson?: boolean }) => {
+            const view = { json: Boolean(options.json), ndjson: Boolean(options.ndjson) }
+            const requested = getRequestedUserRef()
+            const resolution = await resolveActiveAccountSource(requested)
+            if (resolution?.source === 'stored') {
+                const { account: acc, isDefault } = resolution
+                emitView(
+                    view,
+                    { source: 'stored', account: projectAccount(acc, isDefault) },
+                    () => {
+                        const lines = [accountLine(acc, isDefault), `  Base URL: ${acc.baseUrl}`]
+                        if (acc.teamName) lines.push(`  Team: ${acc.teamName}`)
+                        return lines
+                    },
+                )
+                return
+            }
+            if (resolution?.source === 'env') {
                 emitView(view, { source: 'env' }, () => [
                     `Using ${TOKEN_ENV_VAR} environment variable (no stored account).`,
                 ])
                 return
             }
-            if (source === 'legacy') {
+            if (resolution?.source === 'legacy') {
                 emitView(view, { source: 'legacy' }, () => [
                     'Using legacy single-user credentials. Run `ol auth login` to migrate to a stored account.',
                 ])
                 return
             }
+            if (requested !== undefined) {
+                throw new CliError(
+                    'ACCOUNT_NOT_FOUND',
+                    `No stored account matches "${requested}".`,
+                    ['Check the account id or display name, or run `ol auth login` to add it.'],
+                )
+            }
             throw new CliError('NOT_AUTHENTICATED', 'Not authenticated. Run: ol auth login')
-        },
-    })
+        })
 
     attachAccountRemoveCommand<OutlineAccount>(account, {
         store,

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -1,0 +1,150 @@
+import { emitView } from '@doist/cli-core'
+import {
+    type AccountRef,
+    attachAccountCurrentCommand,
+    attachAccountListCommand,
+    attachAccountRemoveCommand,
+    attachAccountUseCommand,
+} from '@doist/cli-core/auth'
+import chalk from 'chalk'
+import type { Command } from 'commander'
+import { TOKEN_ENV_VAR } from '../lib/auth-constants.js'
+import {
+    createOutlineTokenStore,
+    isLegacyAuthActive,
+    type OutlineAccount,
+    type OutlineTokenStore,
+} from '../lib/auth-provider.js'
+import { CliError } from '../lib/errors.js'
+import { getRequestedUserRef, isAccessible } from '../lib/global-args.js'
+import { withUserRefAware } from '../lib/user-ref-store.js'
+import { logTokenStorageResult } from './auth.js'
+
+/** `<label> (id:<id>)` with an accessibility-aware default marker. */
+function accountLine(account: OutlineAccount, isDefault: boolean): string {
+    const marker = isDefault ? (isAccessible() ? ' [default]' : chalk.green(' (default)')) : ''
+    return `${account.label} ${chalk.dim(`(id:${account.id})`)}${marker}`
+}
+
+/** Tidy machine projection shared by `list` and `current` — drops the OAuth client id. */
+function projectAccount(account: OutlineAccount, isDefault: boolean) {
+    return {
+        id: account.id,
+        label: account.label,
+        teamName: account.teamName,
+        baseUrl: account.baseUrl,
+        isDefault,
+    }
+}
+
+/**
+ * `current` resolves whatever the runtime would actually use, but the env-token
+ * and legacy single-user sources aren't stored accounts — outline's store
+ * surfaces them as synthetic snapshots. Short-circuit those (when no explicit
+ * `--user` is in play) to `null` so they route to `onNotAuthenticated` and get
+ * their own messaging instead of rendering as a blank stored account. An
+ * explicit `--user <ref>` always targets a stored account, so it skips the
+ * short-circuit and resolves through the ref-aware store.
+ */
+function currentStore(refAware: OutlineTokenStore): OutlineTokenStore {
+    return {
+        ...refAware,
+        activeAccount: async (ref?: AccountRef) => {
+            const requested = ref ?? getRequestedUserRef()
+            if (requested === undefined) {
+                if (process.env[TOKEN_ENV_VAR]?.trim()) return null
+                if (await isLegacyAuthActive()) return null
+            }
+            return refAware.activeAccount(ref)
+        },
+    }
+}
+
+export function registerAccountCommand(program: Command): void {
+    const account = program.command('account').description('Manage stored CLI accounts')
+    const store = createOutlineTokenStore()
+    const refAware = withUserRefAware(store)
+
+    attachAccountListCommand<OutlineAccount>(account, {
+        store,
+        description: 'List stored Outline accounts',
+        renderText: ({ accounts }) => {
+            if (accounts.length === 0) {
+                return 'No stored accounts. Run `ol auth login` to add one.'
+            }
+            return accounts.map(({ account, isDefault }) => accountLine(account, isDefault))
+        },
+        renderJson: ({ account, isDefault }) => projectAccount(account, isDefault),
+    })
+
+    attachAccountUseCommand<OutlineAccount>(account, {
+        store,
+        description: 'Set the default account (matched by Outline user id or display name)',
+    })
+
+    attachAccountCurrentCommand<OutlineAccount>(account, {
+        store: currentStore(refAware),
+        description: 'Show the active account (honours --user and OUTLINE_API_TOKEN)',
+        renderText: ({ account, isDefault }) => {
+            const lines = [accountLine(account, isDefault), `  Base URL: ${account.baseUrl}`]
+            if (account.teamName) lines.push(`  Team: ${account.teamName}`)
+            return lines
+        },
+        renderJson: ({ account, isDefault }) => projectAccount(account, isDefault),
+        async onNotAuthenticated({ view }) {
+            if (process.env[TOKEN_ENV_VAR]?.trim()) {
+                emitView(view, { source: 'env' }, () => [
+                    `Using ${TOKEN_ENV_VAR} environment variable (no stored account).`,
+                ])
+                return
+            }
+            if (await isLegacyAuthActive()) {
+                emitView(view, { source: 'legacy' }, () => [
+                    'Using legacy single-user credentials. Run `ol auth login` to migrate to a stored account.',
+                ])
+                return
+            }
+            throw new CliError('NOT_AUTHENTICATED', 'Not authenticated. Run: ol auth login')
+        },
+    })
+
+    attachAccountRemoveCommand<OutlineAccount>(account, {
+        store,
+        description: 'Remove a stored account (clears keyring + config entry)',
+        renderText: ({ account, wasDefault }) => {
+            const lines = [`${chalk.green('✓')} Removed ${account.label ?? account.id}`]
+            if (wasDefault) {
+                lines.push(
+                    chalk.dim(
+                        'Cleared default account. Set a new one with `ol account use <id|name>`.',
+                    ),
+                )
+            }
+            return lines
+        },
+        onRemoved: ({ view }) => {
+            const result = store.getLastClearResult()
+            if (!result) return
+            logTokenStorageResult(
+                result,
+                'Stored token removed from the system credential manager',
+                view.json || view.ndjson,
+            )
+        },
+    })
+
+    // `attachAccountListCommand` registers `list` without commander's default
+    // flag, so wire the parent default explicitly to keep bare `ol account`
+    // listing stored accounts.
+    ;(account as unknown as { _defaultCommandName: string })._defaultCommandName = 'list'
+
+    account.addHelpText(
+        'after',
+        `
+Examples:
+  ol account                     # list stored accounts (default subcommand)
+  ol account current             # show the active account
+  ol account use "Ada Lovelace"  # set the default account (id or display name)
+  ol account remove id-bob       # forget an account (clears keyring + config entry)`,
+    )
+}

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -9,15 +9,15 @@ import {
 import chalk from 'chalk'
 import type { Command } from 'commander'
 import { TOKEN_ENV_VAR } from '../lib/auth-constants.js'
+import { logClearResult } from '../lib/auth-output.js'
 import {
     createOutlineTokenStore,
     type OutlineAccount,
     type OutlineTokenStore,
+    resolveActiveAccountSource,
 } from '../lib/auth-provider.js'
 import { CliError } from '../lib/errors.js'
 import { getRequestedUserRef, isAccessible } from '../lib/global-args.js'
-import { withUserRefAware } from '../lib/user-ref-store.js'
-import { logClearResult } from './auth.js'
 
 /** `<label> (id:<id>)` with an accessibility-aware default marker. */
 function accountLine(account: OutlineAccount, isDefault: boolean): string {
@@ -37,47 +37,49 @@ function projectAccount(account: OutlineAccount, isDefault: boolean) {
 }
 
 /**
- * cli-core's `current` attacher calls `store.activeAccount()` once and renders
- * any non-null result as a stored account. But outline's store also synthesises
- * env-token and legacy single-user snapshots, which aren't real stored accounts.
- *
- * Resolve the ambient source once here and stash it so the render path reports a
- * single discriminated shape (`stored` / `env` / `legacy`) without re-probing
- * config. Precedence mirrors `active()`: an env token wins over stored accounts
- * (but only when no explicit account was requested), while a stored v2 account
- * is preferred over a lingering legacy token — so legacy is only surfaced when
- * the store has no v2 record backing the resolved account.
+ * Adapt the authoritative `resolveActiveAccountSource` to the `activeAccount`
+ * contract cli-core's `current` attacher consumes: a stored account resolves
+ * normally; the out-of-store env/legacy sources resolve to `null` (their source
+ * stashed for `onNotAuthenticated` to render) so they aren't shown as accounts.
+ * A `--user`/positional ref that matches nothing surfaces as `ACCOUNT_NOT_FOUND`,
+ * matching the global `--user` selector elsewhere.
  */
-function makeCurrentResolver(store: OutlineTokenStore, refAware: OutlineTokenStore) {
+function currentResolverStore(store: OutlineTokenStore): {
+    store: OutlineTokenStore
+    getSource: () => 'env' | 'legacy' | undefined
+} {
     let source: 'env' | 'legacy' | undefined
-    const currentStore: OutlineTokenStore = {
-        ...refAware,
+    const wrapped: OutlineTokenStore = {
+        ...store,
         activeAccount: async (ref?: AccountRef) => {
             source = undefined
             const requested = ref ?? getRequestedUserRef()
-            if (requested === undefined && process.env[TOKEN_ENV_VAR]?.trim()) {
-                source = 'env'
+            const resolution = await resolveActiveAccountSource(requested)
+            if (resolution?.source === 'stored') {
+                return { account: resolution.account, isDefault: resolution.isDefault }
+            }
+            if (resolution) {
+                source = resolution.source
                 return null
             }
-            const resolved = await refAware.activeAccount(ref)
-            if (!resolved) return null
-            const isStored = (await store.list()).some(
-                (entry) => entry.account.id === resolved.account.id,
-            )
-            if (isStored) return resolved
-            source = 'legacy'
+            if (requested !== undefined) {
+                throw new CliError(
+                    'ACCOUNT_NOT_FOUND',
+                    `No stored account matches "${requested}".`,
+                    ['Check the account id or display name, or run `ol auth login` to add it.'],
+                )
+            }
             return null
         },
     }
-    return { currentStore, getSource: () => source }
+    return { store: wrapped, getSource: () => source }
 }
 
 export function registerAccountCommand(program: Command): void {
     const account = program.command('account').description('Manage stored CLI accounts')
     const store = createOutlineTokenStore()
-    const refAware = withUserRefAware(store)
 
-    attachAccountListCommand<OutlineAccount>(account, {
+    const list = attachAccountListCommand<OutlineAccount>(account, {
         store,
         description: 'List stored Outline accounts',
         renderText: ({ accounts }) => {
@@ -94,7 +96,7 @@ export function registerAccountCommand(program: Command): void {
         description: 'Set the default account (matched by Outline user id or display name)',
     })
 
-    const { currentStore, getSource } = makeCurrentResolver(store, refAware)
+    const { store: currentStore, getSource } = currentResolverStore(store)
     attachAccountCurrentCommand<OutlineAccount>(account, {
         store: currentStore,
         description: 'Show the active account (honours --user and OUTLINE_API_TOKEN)',
@@ -142,14 +144,13 @@ export function registerAccountCommand(program: Command): void {
         onRemoved: ({ view }) => logClearResult(store, view.json || view.ndjson),
     })
 
-    // `attachAccountListCommand` registers `list` without commander's default
-    // flag, so wire the parent default explicitly to keep bare `ol account`
-    // listing stored accounts. Commander exposes no public setter for this in
-    // the pinned version (`typeof account.defaultCommand === 'undefined'`), and
-    // the attacher owns the `command('list')` call so `{ isDefault: true }` can't
-    // be passed at creation — hence the internal-field assignment (mirrors
-    // twist-cli).
-    ;(account as unknown as { _defaultCommandName: string })._defaultCommandName = 'list'
+    // Make bare `ol account` list. A parent action runs only when no subcommand
+    // matches, so `ol account list` still routes to the subcommand directly —
+    // this just delegates the no-subcommand case via the public API (no reliance
+    // on commander internals).
+    account.action(async () => {
+        await list.parseAsync([], { from: 'user' })
+    })
 
     account.addHelpText(
         'after',

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -11,14 +11,13 @@ import type { Command } from 'commander'
 import { TOKEN_ENV_VAR } from '../lib/auth-constants.js'
 import {
     createOutlineTokenStore,
-    isLegacyAuthActive,
     type OutlineAccount,
     type OutlineTokenStore,
 } from '../lib/auth-provider.js'
 import { CliError } from '../lib/errors.js'
 import { getRequestedUserRef, isAccessible } from '../lib/global-args.js'
 import { withUserRefAware } from '../lib/user-ref-store.js'
-import { logTokenStorageResult } from './auth.js'
+import { logClearResult } from './auth.js'
 
 /** `<label> (id:<id>)` with an accessibility-aware default marker. */
 function accountLine(account: OutlineAccount, isDefault: boolean): string {
@@ -38,26 +37,39 @@ function projectAccount(account: OutlineAccount, isDefault: boolean) {
 }
 
 /**
- * `current` resolves whatever the runtime would actually use, but the env-token
- * and legacy single-user sources aren't stored accounts — outline's store
- * surfaces them as synthetic snapshots. Short-circuit those (when no explicit
- * `--user` is in play) to `null` so they route to `onNotAuthenticated` and get
- * their own messaging instead of rendering as a blank stored account. An
- * explicit `--user <ref>` always targets a stored account, so it skips the
- * short-circuit and resolves through the ref-aware store.
+ * cli-core's `current` attacher calls `store.activeAccount()` once and renders
+ * any non-null result as a stored account. But outline's store also synthesises
+ * env-token and legacy single-user snapshots, which aren't real stored accounts.
+ *
+ * Resolve the ambient source once here and stash it so the render path reports a
+ * single discriminated shape (`stored` / `env` / `legacy`) without re-probing
+ * config. Precedence mirrors `active()`: an env token wins over stored accounts
+ * (but only when no explicit account was requested), while a stored v2 account
+ * is preferred over a lingering legacy token — so legacy is only surfaced when
+ * the store has no v2 record backing the resolved account.
  */
-function currentStore(refAware: OutlineTokenStore): OutlineTokenStore {
-    return {
+function makeCurrentResolver(store: OutlineTokenStore, refAware: OutlineTokenStore) {
+    let source: 'env' | 'legacy' | undefined
+    const currentStore: OutlineTokenStore = {
         ...refAware,
         activeAccount: async (ref?: AccountRef) => {
+            source = undefined
             const requested = ref ?? getRequestedUserRef()
-            if (requested === undefined) {
-                if (process.env[TOKEN_ENV_VAR]?.trim()) return null
-                if (await isLegacyAuthActive()) return null
+            if (requested === undefined && process.env[TOKEN_ENV_VAR]?.trim()) {
+                source = 'env'
+                return null
             }
-            return refAware.activeAccount(ref)
+            const resolved = await refAware.activeAccount(ref)
+            if (!resolved) return null
+            const isStored = (await store.list()).some(
+                (entry) => entry.account.id === resolved.account.id,
+            )
+            if (isStored) return resolved
+            source = 'legacy'
+            return null
         },
     }
+    return { currentStore, getSource: () => source }
 }
 
 export function registerAccountCommand(program: Command): void {
@@ -82,23 +94,28 @@ export function registerAccountCommand(program: Command): void {
         description: 'Set the default account (matched by Outline user id or display name)',
     })
 
+    const { currentStore, getSource } = makeCurrentResolver(store, refAware)
     attachAccountCurrentCommand<OutlineAccount>(account, {
-        store: currentStore(refAware),
+        store: currentStore,
         description: 'Show the active account (honours --user and OUTLINE_API_TOKEN)',
         renderText: ({ account, isDefault }) => {
             const lines = [accountLine(account, isDefault), `  Base URL: ${account.baseUrl}`]
             if (account.teamName) lines.push(`  Team: ${account.teamName}`)
             return lines
         },
-        renderJson: ({ account, isDefault }) => projectAccount(account, isDefault),
-        async onNotAuthenticated({ view }) {
-            if (process.env[TOKEN_ENV_VAR]?.trim()) {
+        renderJson: ({ account, isDefault }) => ({
+            source: 'stored',
+            account: projectAccount(account, isDefault),
+        }),
+        onNotAuthenticated({ view }) {
+            const source = getSource()
+            if (source === 'env') {
                 emitView(view, { source: 'env' }, () => [
                     `Using ${TOKEN_ENV_VAR} environment variable (no stored account).`,
                 ])
                 return
             }
-            if (await isLegacyAuthActive()) {
+            if (source === 'legacy') {
                 emitView(view, { source: 'legacy' }, () => [
                     'Using legacy single-user credentials. Run `ol auth login` to migrate to a stored account.',
                 ])
@@ -112,7 +129,7 @@ export function registerAccountCommand(program: Command): void {
         store,
         description: 'Remove a stored account (clears keyring + config entry)',
         renderText: ({ account, wasDefault }) => {
-            const lines = [`${chalk.green('✓')} Removed ${account.label ?? account.id}`]
+            const lines = [`${chalk.green('✓')} Removed ${account.label}`]
             if (wasDefault) {
                 lines.push(
                     chalk.dim(
@@ -122,20 +139,16 @@ export function registerAccountCommand(program: Command): void {
             }
             return lines
         },
-        onRemoved: ({ view }) => {
-            const result = store.getLastClearResult()
-            if (!result) return
-            logTokenStorageResult(
-                result,
-                'Stored token removed from the system credential manager',
-                view.json || view.ndjson,
-            )
-        },
+        onRemoved: ({ view }) => logClearResult(store, view.json || view.ndjson),
     })
 
     // `attachAccountListCommand` registers `list` without commander's default
     // flag, so wire the parent default explicitly to keep bare `ol account`
-    // listing stored accounts.
+    // listing stored accounts. Commander exposes no public setter for this in
+    // the pinned version (`typeof account.defaultCommand === 'undefined'`), and
+    // the attacher owns the `command('list')` call so `{ isDefault: true }` can't
+    // be passed at creation — hence the internal-field assignment (mirrors
+    // twist-cli).
     ;(account as unknown as { _defaultCommandName: string })._defaultCommandName = 'list'
 
     account.addHelpText(

--- a/src/commands/auth-command.test.ts
+++ b/src/commands/auth-command.test.ts
@@ -261,7 +261,7 @@ describe('logTokenStorageResult', () => {
     it('prints the secure-store confirmation to stdout in human mode', async () => {
         const log = captureConsole()
         const errorSpy = captureConsole('error')
-        const { logTokenStorageResult } = await import('./auth.js')
+        const { logTokenStorageResult } = await import('../lib/auth-output.js')
 
         logTokenStorageResult({ storage: 'secure-store' }, 'Token stored securely', false)
 
@@ -271,7 +271,7 @@ describe('logTokenStorageResult', () => {
 
     it('suppresses the stdout confirmation in machine-output mode', async () => {
         const log = captureConsole()
-        const { logTokenStorageResult } = await import('./auth.js')
+        const { logTokenStorageResult } = await import('../lib/auth-output.js')
 
         logTokenStorageResult({ storage: 'secure-store' }, 'Token stored securely', true)
 
@@ -281,7 +281,7 @@ describe('logTokenStorageResult', () => {
     it('routes the keyring-fallback warning to stderr (in both human and machine modes)', async () => {
         const log = captureConsole()
         const errorSpy = captureConsole('error')
-        const { logTokenStorageResult } = await import('./auth.js')
+        const { logTokenStorageResult } = await import('../lib/auth-output.js')
 
         logTokenStorageResult(
             { storage: 'config-file', warning: 'system credential manager unavailable' },

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,12 +1,8 @@
-import {
-    attachLoginCommand,
-    attachLogoutCommand,
-    attachStatusCommand,
-    type TokenStorageResult,
-} from '@doist/cli-core/auth'
+import { attachLoginCommand, attachLogoutCommand, attachStatusCommand } from '@doist/cli-core/auth'
 import chalk from 'chalk'
 import type { Command } from 'commander'
 import { apiRequest } from '../lib/api.js'
+import { logClearResult, logTokenStorageResult } from '../lib/auth-output.js'
 import { renderError, renderSuccess } from '../lib/auth-pages.js'
 import {
     type AuthInfoResponse,
@@ -35,44 +31,6 @@ function resolvePreferredCallbackPort(): number {
         return DEFAULT_OAUTH_CALLBACK_PORT
     }
     return parsed
-}
-
-/**
- * Surface a `TokenStorageResult` from a save/clear: the human-readable
- * confirmation goes to stdout, any keyring-fallback warning goes to stderr.
- * Pass `isMachineOutput: true` to suppress the stdout confirmation in
- * `--json` / `--ndjson` mode while still routing the warning to stderr.
- *
- * Exported for direct unit testing — the alternative (driving this via
- * mocked cli-core login/logout hooks) would require stubbing the entire
- * store contract just to assert two console calls.
- */
-export function logTokenStorageResult(
-    result: TokenStorageResult,
-    secureStoreMessage: string,
-    isMachineOutput = false,
-): void {
-    if (!isMachineOutput && result.storage === 'secure-store') {
-        console.log(chalk.dim(secureStoreMessage))
-    }
-    if (result.warning) {
-        console.error(chalk.yellow('Warning:'), result.warning)
-    }
-}
-
-/**
- * Surface the result of a token clear (`auth logout` / `account remove`): the
- * confirmation goes to stdout, any keyring-fallback warning to stderr. Shared so
- * both call sites stay in lockstep.
- */
-export function logClearResult(store: OutlineTokenStore, isMachineOutput: boolean): void {
-    const result = store.getLastClearResult()
-    if (!result) return
-    logTokenStorageResult(
-        result,
-        'Stored token removed from the system credential manager',
-        isMachineOutput,
-    )
 }
 
 export function registerAuthCommand(program: Command): void {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -60,6 +60,21 @@ export function logTokenStorageResult(
     }
 }
 
+/**
+ * Surface the result of a token clear (`auth logout` / `account remove`): the
+ * confirmation goes to stdout, any keyring-fallback warning to stderr. Shared so
+ * both call sites stay in lockstep.
+ */
+export function logClearResult(store: OutlineTokenStore, isMachineOutput: boolean): void {
+    const result = store.getLastClearResult()
+    if (!result) return
+    logTokenStorageResult(
+        result,
+        'Stored token removed from the system credential manager',
+        isMachineOutput,
+    )
+}
+
 export function registerAuthCommand(program: Command): void {
     const auth = program.command('auth').description('Manage authentication')
 
@@ -176,13 +191,7 @@ export function registerAuthCommand(program: Command): void {
         store: refAware,
         description: 'Clear saved authentication',
         onCleared({ view }) {
-            const result = store.getLastClearResult()
-            if (!result) return
-            logTokenStorageResult(
-                result,
-                'Stored token removed from the system credential manager',
-                view.json || view.ndjson,
-            )
+            logClearResult(store, view.json || view.ndjson)
         },
     })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander'
 import packageJson from '../package.json' with { type: 'json' }
+import { registerAccountCommand } from './commands/account.js'
 import { registerAuthCommand } from './commands/auth.js'
 import { registerChangelogCommand } from './commands/changelog.js'
 import { registerCollectionCommand } from './commands/collection.js'
@@ -33,6 +34,7 @@ Note for AI/LLM agents:
     )
 
 registerAuthCommand(program)
+registerAccountCommand(program)
 registerSearchCommand(program)
 registerDocumentCommand(program)
 registerCollectionCommand(program)

--- a/src/lib/auth-output.ts
+++ b/src/lib/auth-output.ts
@@ -1,0 +1,37 @@
+import type { TokenStorageResult } from '@doist/cli-core/auth'
+import chalk from 'chalk'
+import type { OutlineTokenStore } from './auth-provider.js'
+
+/**
+ * Surface a `TokenStorageResult` from a save/clear: the human-readable
+ * confirmation goes to stdout, any keyring-fallback warning goes to stderr.
+ * Pass `isMachineOutput: true` to suppress the stdout confirmation in
+ * `--json` / `--ndjson` mode while still routing the warning to stderr.
+ */
+export function logTokenStorageResult(
+    result: TokenStorageResult,
+    secureStoreMessage: string,
+    isMachineOutput = false,
+): void {
+    if (!isMachineOutput && result.storage === 'secure-store') {
+        console.log(chalk.dim(secureStoreMessage))
+    }
+    if (result.warning) {
+        console.error(chalk.yellow('Warning:'), result.warning)
+    }
+}
+
+/**
+ * Surface the result of a token clear (`auth logout` / `account remove`): the
+ * confirmation goes to stdout, any keyring-fallback warning to stderr. Shared so
+ * both call sites stay in lockstep.
+ */
+export function logClearResult(store: OutlineTokenStore, isMachineOutput: boolean): void {
+    const result = store.getLastClearResult()
+    if (!result) return
+    logTokenStorageResult(
+        result,
+        'Stored token removed from the system credential manager',
+        isMachineOutput,
+    )
+}

--- a/src/lib/auth-provider.test.ts
+++ b/src/lib/auth-provider.test.ts
@@ -22,6 +22,7 @@ const keyringMocks = vi.hoisted(() => ({
     createKeyringTokenStore: vi.fn(),
     inner: {
         active: vi.fn(),
+        activeAccount: vi.fn(),
         activeBundle: vi.fn(),
         set: vi.fn(),
         setBundle: vi.fn(),
@@ -492,6 +493,93 @@ describe('createOutlineTokenStore', () => {
             promoteDefault: true,
         })
         expect(configMocks.updateConfig).toHaveBeenCalledWith(LEGACY_CLEAR_PAYLOAD)
+    })
+})
+
+describe('resolveActiveAccountSource', () => {
+    async function loadResolve(): Promise<
+        typeof import('./auth-provider.js').resolveActiveAccountSource
+    > {
+        vi.resetModules()
+        return (await import('./auth-provider.js')).resolveActiveAccountSource
+    }
+
+    beforeEach(() => {
+        delete process.env[TOKEN_ENV_VAR]
+        keyringMocks.inner.activeAccount.mockReset().mockResolvedValue(null)
+        migrateMocks.runMigrateLegacyAuth
+            .mockReset()
+            .mockResolvedValue({ status: 'no-legacy-state' })
+        configMocks.getConfig.mockReset().mockResolvedValue({})
+    })
+
+    afterEach(() => {
+        vi.unstubAllEnvs()
+    })
+
+    it('reports env (and bypasses migration + the v2 store) when OUTLINE_API_TOKEN is set and no ref', async () => {
+        vi.stubEnv(TOKEN_ENV_VAR, 'env_token_value')
+        const resolveActiveAccountSource = await loadResolve()
+
+        await expect(resolveActiveAccountSource()).resolves.toEqual({ source: 'env' })
+        expect(keyringMocks.inner.activeAccount).not.toHaveBeenCalled()
+        expect(migrateMocks.runMigrateLegacyAuth).not.toHaveBeenCalled()
+    })
+
+    it('reports the stored v2 account with its default marker', async () => {
+        keyringMocks.inner.activeAccount.mockResolvedValue({
+            account: STORED_ACCOUNT,
+            isDefault: true,
+        })
+        const resolveActiveAccountSource = await loadResolve()
+
+        await expect(resolveActiveAccountSource()).resolves.toEqual({
+            source: 'stored',
+            account: STORED_ACCOUNT,
+            isDefault: true,
+        })
+    })
+
+    it('prefers a stored v2 account over a lingering legacy token (inconclusive migration)', async () => {
+        // A legacy api_token is still on disk and migration is inconclusive, but
+        // the v2 store resolves a default — the stored account must win.
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
+        configMocks.getConfig.mockResolvedValue(LEGACY_CONFIG)
+        keyringMocks.inner.activeAccount.mockResolvedValue({
+            account: STORED_ACCOUNT,
+            isDefault: true,
+        })
+        const resolveActiveAccountSource = await loadResolve()
+
+        await expect(resolveActiveAccountSource()).resolves.toMatchObject({ source: 'stored' })
+    })
+
+    it('reports legacy only when the v2 store has no matching record', async () => {
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
+        configMocks.getConfig.mockResolvedValue(LEGACY_CONFIG)
+        keyringMocks.inner.activeAccount.mockResolvedValue(null)
+        const resolveActiveAccountSource = await loadResolve()
+
+        await expect(resolveActiveAccountSource()).resolves.toEqual({ source: 'legacy' })
+    })
+
+    it('does not misreport a renamed legacy snapshot as stored when --user matches the old name only', async () => {
+        // Regression for UUID-equality misclassification: the v2 record was
+        // renamed (so it no longer matches the old display name), while the
+        // legacy snapshot still carries it. `--user <old-name>` must resolve to
+        // legacy, not stored.
+        migrateMocks.runMigrateLegacyAuth.mockResolvedValue(SKIPPED_RESULT)
+        configMocks.getConfig.mockResolvedValue(LEGACY_CONFIG) // legacy label "Ada"
+        keyringMocks.inner.activeAccount.mockResolvedValue(null) // v2 record no longer matches "Ada"
+        const resolveActiveAccountSource = await loadResolve()
+
+        await expect(resolveActiveAccountSource('Ada')).resolves.toEqual({ source: 'legacy' })
+        expect(keyringMocks.inner.activeAccount).toHaveBeenCalledWith('Ada')
+    })
+
+    it('returns null when nothing is active', async () => {
+        const resolveActiveAccountSource = await loadResolve()
+        await expect(resolveActiveAccountSource()).resolves.toBeNull()
     })
 })
 

--- a/src/lib/auth-provider.ts
+++ b/src/lib/auth-provider.ts
@@ -216,13 +216,48 @@ export async function isLegacyAuthActive(): Promise<boolean> {
  * propagates it so a failed logout fails loudly instead of leaving the
  * user authenticated via the legacy fallback.
  */
-export function createOutlineTokenStore(): OutlineTokenStore {
-    const inner = createKeyringTokenStore<OutlineAccount>({
+/** The bare cli-core keyring store (v2 records only — no env/legacy fallback). */
+function createInnerStore(): KeyringTokenStore<OutlineAccount> {
+    return createKeyringTokenStore<OutlineAccount>({
         serviceName: SECURE_STORE_SERVICE,
         userRecords: createOutlineUserRecordStore(),
         recordsLocation: getConfigPath(),
         matchAccount: matchOutlineAccount,
     })
+}
+
+/** Where `ol account current` resolves the active credential from. */
+export type ActiveAccountSource =
+    | { source: 'stored'; account: OutlineAccount; isDefault: boolean }
+    | { source: 'env' }
+    | { source: 'legacy' }
+    | null
+
+/**
+ * Authoritatively classify the active credential without re-deriving the
+ * cascade from membership heuristics. Mirrors `active()`'s precedence — env
+ * (only when no explicit ref) → stored v2 → legacy snapshot — but reports
+ * *which* branch matched, so `ol account current` can render the right shape.
+ *
+ * The v2 lookup uses the bare keyring store (no legacy fallback) and matches by
+ * `ref`, so a renamed legacy snapshot sharing a UUID with a v2 record can't be
+ * misreported as `stored`: a `--user <old-name>` that the v2 record no longer
+ * matches falls through to the legacy branch.
+ */
+export async function resolveActiveAccountSource(ref?: AccountRef): Promise<ActiveAccountSource> {
+    if (ref === undefined && process.env[TOKEN_ENV_VAR]?.trim()) return { source: 'env' }
+    await ensureMigrated()
+    const stored = await createInnerStore().activeAccount(ref)
+    if (stored) return { source: 'stored', account: stored.account, isDefault: stored.isDefault }
+    const legacy = await readLegacyTokenSnapshot()
+    if (legacy && (ref === undefined || matchOutlineAccount(legacy.account, ref))) {
+        return { source: 'legacy' }
+    }
+    return null
+}
+
+export function createOutlineTokenStore(): OutlineTokenStore {
+    const inner = createInnerStore()
     async function migrationIsInconclusive(): Promise<boolean> {
         const result = await ensureMigrated() // memoised
         return result === null || !migrationIsConclusive(result)

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -14,6 +14,7 @@ Use this skill when the user wants to interact with their Outline wiki/knowledge
 - \`ol doc open <id>\` - Open document in browser
 - \`ol doc create --title "Title" --collection <id>\` - Create document
 - \`ol col list\` - List collections
+- \`ol account\` - List stored accounts; \`ol account use <id|name>\` sets the default
 
 ## Output Formats
 
@@ -86,6 +87,19 @@ ol auth status                         # Show current auth state
 ol auth status --json | --ndjson       # Machine-readable status envelope ({id, team, baseUrl, source})
 ol auth logout                         # Clear saved credentials
 ol auth logout --json | --ndjson       # Machine-readable logout envelope ({ok: true}; --ndjson is silent)
+\`\`\`
+
+### Accounts
+\`\`\`bash
+ol account                             # List stored accounts (default subcommand)
+ol account list                        # List stored accounts, default marked
+ol account list --json | --ndjson      # Machine-readable list ({accounts, default}; --ndjson streams one per line)
+ol account current                     # Show the active account (honours --user and OUTLINE_API_TOKEN)
+ol account current --json | --ndjson   # Machine-readable active account ({id, label, teamName, baseUrl, isDefault})
+ol account use <id|name>               # Set the default account used when --user is omitted
+ol account use <id|name> --json        # Machine-readable envelope ({ok: true, default: <id>}; --ndjson is silent)
+ol account remove <id|name>            # Remove a stored account (clears keyring + config entry)
+ol account remove <id|name> --json     # Machine-readable envelope ({ok: true, removed: <id>}; --ndjson is silent)
 \`\`\`
 
 ### Update & Changelog

--- a/src/lib/skills/content.ts
+++ b/src/lib/skills/content.ts
@@ -95,7 +95,7 @@ ol account                             # List stored accounts (default subcomman
 ol account list                        # List stored accounts, default marked
 ol account list --json | --ndjson      # Machine-readable list ({accounts, default}; --ndjson streams one per line)
 ol account current                     # Show the active account (honours --user and OUTLINE_API_TOKEN)
-ol account current --json | --ndjson   # Machine-readable active account ({id, label, teamName, baseUrl, isDefault})
+ol account current --json | --ndjson   # Discriminated by source: {source:"stored", account:{id, label, teamName, baseUrl, isDefault}} | {source:"env"} | {source:"legacy"}
 ol account use <id|name>               # Set the default account used when --user is omitted
 ol account use <id|name> --json        # Machine-readable envelope ({ok: true, default: <id>}; --ndjson is silent)
 ol account remove <id|name>            # Remove a stored account (clears keyring + config entry)


### PR DESCRIPTION
## Summary

Surfaces the multi-account storage (already shipped in #77 — `users[]` config, keyring, `--user` selector, `withUserRefAware` store-wrap) to users via a new `ol account` command group, wiring cli-core's four generic account attachers.

- `ol account list` (and bare `ol account`, via default subcommand) — lists stored accounts with an accessibility-aware default marker; `--json` emits a `{ accounts, default }` envelope, `--ndjson` streams one per line.
- `ol account use <id|name>` — sets the default account used when `--user` is omitted.
- `ol account current` — shows the active account, honours `ol --user <ref>`, and reports the `OUTLINE_API_TOKEN` env source and legacy single-user sessions via `onNotAuthenticated` (rather than rendering them as a blank stored account).
- `ol account remove <id|name>` — clears the keyring + config entry and surfaces any keyring-fallback warning.
- Machine output drops the OAuth client id (`{ id, label, teamName, baseUrl, isDefault }`).

Reuses existing plumbing: `createOutlineTokenStore`, `withUserRefAware`, `matchOutlineAccount`, `logTokenStorageResult`. No changes to the env/legacy resolution logic beyond a read-only wrapper for `current`.

## Test plan

- [x] `npm run type-check`
- [x] `npm run test` — 200/200 pass, incl. new `src/commands/account.test.ts` (list/use/current/remove, env-token, legacy, empty, not-authenticated)
- [x] `npm run format:check` clean
- [x] `npm run check:skill-sync` in sync
- [x] `node dist/index.js account --help` renders all four subcommands + examples
- [ ] Manual smoke against a real multi-account config: `ol account`, `ol account use`, `ol --user <ref> account current`, `OUTLINE_API_TOKEN=… ol account current`

🤖 Generated with [Claude Code](https://claude.com/claude-code)