### PR TITLE
fix: pin undici to 7.24.8 and block renovate updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"marked-terminal-renderer": "2.2.0",
 				"oauth4webapi": "3.8.6",
 				"open": "10.2.0",
-				"undici": "7.22.0"
+				"undici": "7.24.8"
 			},
 			"bin": {
 				"ol": "dist/index.js"
@@ -9665,9 +9665,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+			"integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"marked-terminal-renderer": "2.2.0",
 		"oauth4webapi": "3.8.6",
 		"open": "10.2.0",
-		"undici": "7.22.0"
+		"undici": "7.24.8"
 	},
 	"devDependencies": {
 		"@semantic-release/changelog": "6.0.3",

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>doist/renovate-config:frontend-base"]
+    "extends": ["github>doist/renovate-config:frontend-base"],
+    "packageRules": [
+        {
+            "matchPackageNames": ["undici"],
+            "enabled": false,
+            "description": "Pin undici to 7.24.8 - block renovate updates to avoid the Node 26 regression in newer 7.x releases"
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- Bump the `undici` pin from 7.22.0 to 7.24.8 to align with the SDKs.
- Add a `packageRule` to disable renovate updates for `undici` so the pin holds, avoiding the Node 26 regression seen with undici 7.27.1 in the decompression dispatcher path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)