### PR TITLE
chore: group oxlint and oxfmt renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
             "matchPackageNames": ["undici"],
             "enabled": false,
             "description": "Pin undici to 7.24.8 - block renovate updates to avoid the Node 26 regression in newer 7.x releases"
+        },
+        {
+            "matchPackageNames": ["oxlint", "oxfmt"],
+            "groupName": "ox toolchain",
+            "description": "Group oxlint and oxfmt updates into a single PR"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- Add a renovate `packageRule` grouping `oxlint` and `oxfmt` updates into a single PR, so the ox toolchain bumps together.

Mirrors Doist/automations#3164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)