### PR TITLE
fix: build a working dispatcher on runtimes without undici's decompress interceptor (e.g. Bun)

### DIFF
--- a/src/transport/http-dispatcher.test.ts
+++ b/src/transport/http-dispatcher.test.ts
@@ -54,6 +54,34 @@ describe('http-dispatcher', () => {
         expect(proxiedDispatcher).not.toBe(directDispatcher)
     })
 
+    it('skips the decompress interceptor when the runtime undici lacks it (e.g. Bun)', async () => {
+        // Bun reports `process.versions.node` but ships a partial undici whose
+        // `interceptors.decompress` is absent. Building the dispatcher must not
+        // throw there — the base agent alone is correct because Bun's `fetch`
+        // decompresses natively.
+        vi.doMock('undici', async () => {
+            const actual = await vi.importActual<typeof import('undici')>('undici')
+            return {
+                ...actual,
+                interceptors: {
+                    ...actual.interceptors,
+                    decompress: undefined,
+                },
+            }
+        })
+
+        try {
+            const { getDefaultDispatcher } = await import('./http-dispatcher.js')
+            const dispatcher = getDefaultDispatcher()
+
+            expect(dispatcher).toBeDefined()
+            expect(typeof dispatcher.dispatch).toBe('function')
+        } finally {
+            vi.doUnmock('undici')
+            vi.resetModules()
+        }
+    })
+
     it('decompresses gzip-encoded response bodies', async () => {
         const payload = { hello: 'world', nested: { value: 42 } }
         const compressed = gzipSync(Buffer.from(JSON.stringify(payload)))

--- a/src/transport/http-dispatcher.test.ts
+++ b/src/transport/http-dispatcher.test.ts
@@ -59,6 +59,10 @@ describe('http-dispatcher', () => {
         // `interceptors.decompress` is absent. Building the dispatcher must not
         // throw there — the base agent alone is correct because Bun's `fetch`
         // decompresses natively.
+        // Clear the module cache first so the fresh `http-dispatcher.js` import
+        // below re-evaluates against the mocked `undici` instead of a copy that
+        // earlier tests already bound to the real one.
+        vi.resetModules()
         vi.doMock('undici', async () => {
             const actual = await vi.importActual<typeof import('undici')>('undici')
             return {
@@ -77,8 +81,10 @@ describe('http-dispatcher', () => {
             expect(dispatcher).toBeDefined()
             expect(typeof dispatcher.dispatch).toBe('function')
         } finally {
+            // Leave `resetModules` to `afterEach`: it must reach this same
+            // module instance to close the dispatcher created above before the
+            // cache is cleared, otherwise the dispatcher leaks.
             vi.doUnmock('undici')
-            vi.resetModules()
         }
     })
 

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -28,8 +28,9 @@ function createDefaultDispatcher(): Dispatcher {
     // undici: `interceptors.decompress` is absent and dispatchers have no
     // `.compose`. Bun is the common case. There the base agent alone is
     // enough — Bun's `fetch` decompresses gzip/deflate/br/zstd natively — so
-    // skip the interceptor instead of crashing on the missing API.
-    if (typeof interceptors.decompress !== 'function') {
+    // skip the interceptor instead of crashing on the missing API. Optional
+    // chaining also guards a runtime that omits the `interceptors` export.
+    if (typeof interceptors?.decompress !== 'function') {
         return base
     }
 

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -24,6 +24,15 @@ function createDefaultDispatcher(): Dispatcher {
         ? new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS)
         : new Agent(KEEP_ALIVE_OPTIONS)
 
+    // Some runtimes report `process.versions.node` but ship only a partial
+    // undici: `interceptors.decompress` is absent and dispatchers have no
+    // `.compose`. Bun is the common case. There the base agent alone is
+    // enough — Bun's `fetch` decompresses gzip/deflate/br/zstd natively — so
+    // skip the interceptor instead of crashing on the missing API.
+    if (typeof interceptors.decompress !== 'function') {
+        return base
+    }
+
     // Compose the response-decompression interceptor so gzip/deflate/br/zstd
     // bodies are decoded before consumers parse them. Required on Node 24+:
     // attaching any custom dispatcher to the global `fetch` strips the


### PR DESCRIPTION
## Problem

`createDefaultDispatcher()` unconditionally calls `interceptors.decompress()` and `.compose()`. **Bun** ships only a partial undici shim that implements neither, so running the CLI under Bun throws while building the default dispatcher:

```
TypeError: interceptors.decompress is not a function
```

## Fix

Feature-detect `interceptors.decompress`. When it isn't a function, return the bare base agent (`Agent` or `EnvHttpProxyAgent` depending on proxy env) — Bun's `fetch` decompresses `gzip`/`deflate`/`br`/`zstd` natively, so the agent on its own is already correct. On real Node nothing changes: the decompress interceptor is still composed exactly as before.

It's deliberately a **capability check, not a `Bun` name-check**, so it:
- self-heals automatically if a future Bun implements `interceptors.decompress`, and
- covers any other runtime that ships a partial undici.

## Testing

- Added a unit test that mocks a partial undici (no `decompress`) and asserts the dispatcher still builds.
- The full `http-dispatcher` suite, oxlint, oxfmt, and type-check all pass (pre-commit hooks green).

Mirrors Doist/todoist-sdk-typescript#616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)