### PR TITLE
ci: bump GitHub Action pins to node24-compatible majors

### DIFF
--- a/.github/workflows/check-skill-sync.yml
+++ b/.github/workflows/check-skill-sync.yml
@@ -13,7 +13,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
               uses: actions/setup-node@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
               uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,13 @@ jobs:
                   GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   token: ${{ steps.generate_token.outputs.token }}
                   fetch-depth: 0
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version-file: .nvmrc
                   cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
               uses: actions/setup-node@v6


### PR DESCRIPTION
Bumps GitHub Action pins to majors that ship with the node24 runtime, ahead of GitHub's node20 deprecation.

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6

Tracking: https://github.com/Doist/platform-backlog/issues/1385
