### PR TITLE
ci: announce releases via comms action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,15 @@ jobs:
                       echo "EOF"
                   } >> "$GITHUB_OUTPUT"
 
-            - name: Announce release in Twist
+            - name: Announce release in Comms
               if: github.ref_name == 'main' && steps.announcement.outputs.should_announce == 'true'
-              uses: Doist/twist-post-action@74a0255b75ad93c06b9eb1009960106efe13f5ca
+              uses: Doist/comms-actions/post-comment-action@cf057e327f43e3ded8a54ebc871911d2b44027e4
               with:
-                  message: ${{ steps.announcement.outputs.message }}
-                  install_id: ${{ secrets.TWIST_RELEASE_INSTALL_ID }}
-                  install_token: ${{ secrets.TWIST_RELEASE_INSTALL_TOKEN }}
+                  comms-client-id: ${{ secrets.COMMS_CLIENT_ID }}
+                  comms-client-secret: ${{ secrets.COMMS_CLIENT_SECRET }}
+                  comms-username: ${{ secrets.COMMS_USERNAME }}
+                  comms-password: ${{ secrets.COMMS_PASSWORD }}
+                  workspace-id: 69
+                  thread-id: BPZsUohfX5WV4tFJKMHAh
+                  content: ${{ steps.announcement.outputs.message }}
               continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,6 @@ jobs:
                   comms-username: ${{ secrets.COMMS_USERNAME }}
                   comms-password: ${{ secrets.COMMS_PASSWORD }}
                   workspace-id: 69
-                  thread-id: BPZsUohfX5WV4tFJKMHAh
+                  thread-id: CZECS4Yebwx7c1c8hDRmB
                   content: ${{ steps.announcement.outputs.message }}
               continue-on-error: true


### PR DESCRIPTION
## Summary

Replaces the release announcement workflow's Twist action with Doist/comms-actions/post-comment-action
