### PR TITLE
chore: block conventional-changelog preset 10.x in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
             "matchPackageNames": ["oxlint", "oxfmt"],
             "groupName": "ox toolchain",
             "description": "Group oxlint and oxfmt updates into a single PR"
+        },
+        {
+            "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+            "allowedVersions": "<10",
+            "description": "10.x requires conventional-changelog-writer@9; semantic-release still pins writer 8, so the preset throws at generateNotes"
         }
     ]
 }


### PR DESCRIPTION
Renovate's config file has been in this repo since #25, but the Renovate app has never run against `Doist/outline-cli` — no dependency dashboard issue, no Renovate PR has ever been opened here, and `npm outdated` lists 17 stale packages including several majors. The app needs enabling for the repo in the org's GitHub App settings; this PR just makes sure the config is right for when it does start running.

`conventional-changelog-conventionalcommits@10.x` hard-requires `conventional-changelog-writer@9`. `semantic-release@25.x` resolves `@semantic-release/release-notes-generator@14.x`, which pins `conventional-changelog-writer@^8.0.0` — 8.4.0 is what's installed here — so a bump to the 10.x preset would make the release job throw at `generateNotes` with `Missing helper: "conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer"`. That's exactly what happened in todoist-cli when Renovate moved it to 10.4.0 (Doist/todoist-cli#490), taking out a release; the fix there was the same `allowedVersions: "<10"` rule (Doist/todoist-cli#493).

We're on the preset at 9.3.0 today, so nothing is broken right now — this stops the first Renovate run from breaking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xoHmYxj4bbWRNFTZjvEci