### PR TITLE
fix: pair the undici dispatcher with its own fetch and bump to 7.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"marked-terminal-renderer": "2.2.0",
 				"oauth4webapi": "3.8.6",
 				"open": "10.2.0",
-				"undici": "7.24.8"
+				"undici": "^7.29.0"
 			},
 			"bin": {
 				"ol": "dist/index.js"
@@ -9665,9 +9665,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-			"integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"marked-terminal-renderer": "2.2.0",
 		"oauth4webapi": "3.8.6",
 		"open": "10.2.0",
-		"undici": "7.24.8"
+		"undici": "^7.29.0"
 	},
 	"devDependencies": {
 		"@semantic-release/changelog": "6.0.3",

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,8 @@
     "packageRules": [
         {
             "matchPackageNames": ["undici"],
-            "enabled": false,
-            "description": "Pin undici to 7.24.8 - block renovate updates to avoid the Node 26 regression in newer 7.x releases"
+            "allowedVersions": "<8",
+            "description": "An undici 8 dispatcher hangs indefinitely against Node 24's built-in fetch, so stay on the 7.x line"
         },
         {
             "matchPackageNames": ["oxlint", "oxfmt"],

--- a/src/transport/fetch-with-retry.test.ts
+++ b/src/transport/fetch-with-retry.test.ts
@@ -1,4 +1,6 @@
-import type { Dispatcher } from 'undici'
+import { createServer, type IncomingMessage, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { Agent, type Dispatcher, fetch as undiciFetch } from 'undici'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { okResponse } from '../_fixtures/auth.js'
 import { captureProxyEnv, clearProxyEnv, restoreProxyEnv } from '../_fixtures/proxy-env.js'
@@ -13,10 +15,10 @@ const transport = vi.hoisted(() => ({
     dispatcher: { id: 'test-dispatcher' } as unknown as Dispatcher,
     fetch: undefined as typeof fetch | undefined,
 }))
+const defaultTestDispatcher = transport.dispatcher
 
 vi.mock('./http-dispatcher.js', () => ({
     getDefaultTransport: () => ({ dispatcher: transport.dispatcher, fetch: transport.fetch }),
-    resetDefaultDispatcherForTests: vi.fn(() => Promise.resolve()),
 }))
 
 /** A `fetch` impl that never resolves and rejects with the abort reason on signal. */
@@ -45,6 +47,7 @@ describe('fetchWithRetry', () => {
 
     afterEach(() => {
         transport.fetch = undefined
+        transport.dispatcher = defaultTestDispatcher
         restoreProxyEnv(originalProxyEnv)
         vi.useRealTimers()
         vi.unstubAllGlobals()
@@ -177,5 +180,82 @@ describe('fetchWithRetry', () => {
                 signal: expect.any(AbortSignal),
             }),
         )
+    })
+    it('flattens a global Request into a URL and init', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(okResponse({ ok: true }))
+        vi.stubGlobal('fetch', fetchMock)
+
+        const { fetchWithRetry } = await import('./fetch-with-retry.js')
+        await fetchWithRetry({
+            url: new Request('https://test.outline.com/api/documents.info', {
+                method: 'POST',
+                headers: { 'x-custom': 'kept' },
+                body: 'payload',
+            }),
+        })
+
+        const [requestUrl, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit]
+        expect(requestUrl).toBe('https://test.outline.com/api/documents.info')
+        expect(requestInit.method).toBe('POST')
+        expect(Object.fromEntries(requestInit.headers as string[][])).toMatchObject({
+            'x-custom': 'kept',
+        })
+        expect(new TextDecoder().decode(requestInit.body as ArrayBuffer)).toBe('payload')
+    })
+
+    it('lets explicit options win over the fields carried on a Request', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(okResponse({ ok: true }))
+        vi.stubGlobal('fetch', fetchMock)
+
+        const { fetchWithRetry } = await import('./fetch-with-retry.js')
+        await fetchWithRetry({
+            url: new Request('https://test.outline.com/api/documents.info', { method: 'POST' }),
+            options: { method: 'PUT' },
+        })
+
+        expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: 'PUT' })
+    })
+
+    it('sends a global Request through the real paired undici fetch', async () => {
+        // The regression this guards: undici's `fetch` only recognises its own
+        // `Request` class and stringifies a global one, so the request fails
+        // with `Failed to parse URL from [object Request]`. Runs against a real
+        // server through the real undici fetch — a mock cannot see this.
+        const received: { method?: string; header?: string; body: string } = { body: '' }
+        const httpServer: Server = await new Promise((resolve) => {
+            const s = createServer((req: IncomingMessage, res) => {
+                received.method = req.method
+                received.header = req.headers['x-custom'] as string
+                req.on('data', (chunk) => {
+                    received.body += String(chunk)
+                })
+                req.on('end', () => {
+                    res.writeHead(200, { 'content-type': 'application/json' })
+                    res.end(JSON.stringify({ ok: true }))
+                })
+            })
+            s.listen(0, '127.0.0.1', () => resolve(s))
+        })
+        const agent = new Agent()
+        transport.dispatcher = agent
+        transport.fetch = undiciFetch as unknown as typeof fetch
+
+        try {
+            const { port } = httpServer.address() as AddressInfo
+            const { fetchWithRetry } = await import('./fetch-with-retry.js')
+            const response = await fetchWithRetry({
+                url: new Request(`http://127.0.0.1:${port}/api/documents.info`, {
+                    method: 'POST',
+                    headers: { 'x-custom': 'kept' },
+                    body: 'payload',
+                }),
+            })
+
+            expect(response.status).toBe(200)
+            expect(received).toEqual({ method: 'POST', header: 'kept', body: 'payload' })
+        } finally {
+            await agent.close()
+            await new Promise<void>((resolve) => httpServer.close(() => resolve()))
+        }
     })
 })

--- a/src/transport/fetch-with-retry.test.ts
+++ b/src/transport/fetch-with-retry.test.ts
@@ -1,8 +1,23 @@
+import type { Dispatcher } from 'undici'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { okResponse } from '../_fixtures/auth.js'
 import { captureProxyEnv, clearProxyEnv, restoreProxyEnv } from '../_fixtures/proxy-env.js'
 
 const originalProxyEnv = captureProxyEnv()
+
+// Stand in for the real transport so these tests can drive both halves of the
+// pairing: `fetch: undefined` routes through the global `fetch` (which every
+// test below stubs), and setting `fetch` exercises the paired-fetch path.
+// Dispatcher selection itself is covered in `http-dispatcher.test.ts`.
+const transport = vi.hoisted(() => ({
+    dispatcher: { id: 'test-dispatcher' } as unknown as Dispatcher,
+    fetch: undefined as typeof fetch | undefined,
+}))
+
+vi.mock('./http-dispatcher.js', () => ({
+    getDefaultTransport: () => ({ dispatcher: transport.dispatcher, fetch: transport.fetch }),
+    resetDefaultDispatcherForTests: vi.fn(() => Promise.resolve()),
+}))
 
 /** A `fetch` impl that never resolves and rejects with the abort reason on signal. */
 function abortableFetch(_url: RequestInfo | URL, options?: RequestInit): Promise<Response> {
@@ -28,9 +43,8 @@ describe('fetchWithRetry', () => {
         vi.spyOn(process, 'emitWarning').mockImplementation(() => {})
     })
 
-    afterEach(async () => {
-        const { resetDefaultDispatcherForTests } = await import('./http-dispatcher.js')
-        await resetDefaultDispatcherForTests()
+    afterEach(() => {
+        transport.fetch = undefined
         restoreProxyEnv(originalProxyEnv)
         vi.useRealTimers()
         vi.unstubAllGlobals()
@@ -43,7 +57,6 @@ describe('fetchWithRetry', () => {
         fetchMock.mockResolvedValue(okResponse({ ok: true }))
         vi.stubGlobal('fetch', fetchMock)
 
-        const { getDefaultDispatcher } = await import('./http-dispatcher.js')
         const { fetchWithRetry } = await import('./fetch-with-retry.js')
         const response = await fetchWithRetry({
             url: 'https://test.outline.com/api/documents.info',
@@ -53,9 +66,32 @@ describe('fetchWithRetry', () => {
         expect(fetchMock).toHaveBeenCalledTimes(1)
         expect(fetchMock).toHaveBeenCalledWith('https://test.outline.com/api/documents.info', {
             method: 'POST',
-            dispatcher: getDefaultDispatcher(),
+            dispatcher: transport.dispatcher,
         })
         expect(response.ok).toBe(true)
+    })
+
+    it('uses the fetch paired with the dispatcher in preference to the global one', async () => {
+        // The dispatcher decompresses the body itself, so the request has to go
+        // through the `fetch` from the same undici build. Reaching for the
+        // global `fetch` instead makes it decode an already-decoded body and
+        // the request fails with `terminated` on Node 26.
+        const globalFetch = vi.fn().mockResolvedValue(okResponse({ ok: true }))
+        vi.stubGlobal('fetch', globalFetch)
+        const pairedFetch = vi.fn().mockResolvedValue(okResponse({ paired: true }))
+        transport.fetch = pairedFetch as unknown as typeof fetch
+
+        const { fetchWithRetry } = await import('./fetch-with-retry.js')
+        await fetchWithRetry({
+            url: 'https://test.outline.com/api/documents.info',
+            options: { method: 'POST' },
+        })
+
+        expect(globalFetch).not.toHaveBeenCalled()
+        expect(pairedFetch).toHaveBeenCalledWith('https://test.outline.com/api/documents.info', {
+            method: 'POST',
+            dispatcher: transport.dispatcher,
+        })
     })
 
     it('retries network errors when configured', async () => {
@@ -115,7 +151,6 @@ describe('fetchWithRetry', () => {
         fetchMock.mockImplementation(abortableFetch)
         vi.stubGlobal('fetch', fetchMock)
 
-        const { getDefaultDispatcher } = await import('./http-dispatcher.js')
         const { fetchWithRetry } = await import('./fetch-with-retry.js')
 
         const requestPromise = fetchWithRetry({
@@ -138,7 +173,7 @@ describe('fetchWithRetry', () => {
             'https://test.outline.com/api/documents.info',
             expect.objectContaining({
                 method: 'GET',
-                dispatcher: getDefaultDispatcher(),
+                dispatcher: transport.dispatcher,
                 signal: expect.any(AbortSignal),
             }),
         )

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -1,4 +1,4 @@
-import { getDefaultDispatcher } from './http-dispatcher.js'
+import { getDefaultTransport } from './http-dispatcher.js'
 
 interface RetryConfig {
     retries: number
@@ -99,10 +99,20 @@ export async function fetchWithRetry(args: FetchWithRetryArgs): Promise<Response
                 ...requestOptions,
                 signal: requestSignal,
             }
+            // Take the dispatcher and its `fetch` as one value: the dispatcher
+            // decompresses the body itself, so a `fetch` from a different
+            // undici build decodes it a second time and the request fails with
+            // `terminated`. A `fetch` of `undefined` means the global one is
+            // the right partner (see `DefaultTransport`).
+            const transport = getDefaultTransport()
             // @ts-expect-error dispatcher is supported by Node.js fetch via Undici
-            fetchOptions.dispatcher = getDefaultDispatcher()
+            fetchOptions.dispatcher = transport.dispatcher
 
-            const response = await fetch(url, fetchOptions)
+            // undici's `fetch` and the global `fetch` have the same call shape;
+            // the cast only reconciles undici's own Request/Response types with
+            // the global lib types.
+            const fetchImpl = (transport.fetch ?? fetch) as typeof fetch
+            const response = await fetchImpl(url, fetchOptions)
             if (clearTimeoutFn) {
                 clearTimeoutFn()
             }

--- a/src/transport/fetch-with-retry.ts
+++ b/src/transport/fetch-with-retry.ts
@@ -78,8 +78,59 @@ function createTimeoutSignal(
     return { signal: controller.signal, clear }
 }
 
+/**
+ * Both `Request` classes in play here — the global one and undici's — reject
+ * each other's instances: the check is a plain `instanceof`, and anything that
+ * fails it gets stringified, so the request dies with `Failed to parse URL
+ * from [object Request]`. Duck-typing catches either class.
+ */
+function isRequestLike(value: unknown): value is Request {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'url' in value &&
+        'method' in value &&
+        'headers' in value
+    )
+}
+
+/**
+ * Flatten a `Request` input into a plain URL and init, so neither `fetch`
+ * implementation is ever handed a `Request` the other one owns.
+ * `fetchWithRetry` is exposed as a `typeof fetch` (see `outlineFetch` in
+ * `auth-provider.ts`), so a `Request` is a shape callers may legitimately pass.
+ *
+ * Reading the body to a buffer up front also keeps it replayable: a request
+ * stream is consumed by the first attempt and would replay as an empty body.
+ *
+ * Explicit `options` win over the request's own fields, matching
+ * `fetch(request, init)`.
+ */
+async function flattenRequestInput(
+    url: RequestInfo | URL,
+    options: FetchOptions,
+): Promise<{ url: string | URL; options: FetchOptions }> {
+    if (typeof url === 'string' || url instanceof URL || !isRequestLike(url)) {
+        return { url: url as string | URL, options }
+    }
+
+    const body = url.body ? await url.arrayBuffer() : undefined
+
+    return {
+        url: url.url,
+        options: {
+            method: url.method,
+            headers: [...url.headers],
+            ...(body === undefined ? {} : { body }),
+            ...(url.signal ? { signal: url.signal } : {}),
+            ...options,
+        },
+    }
+}
+
 export async function fetchWithRetry(args: FetchWithRetryArgs): Promise<Response> {
-    const { url, options = {}, retryConfig = {} } = args
+    const { url, options: rawOptions = {}, retryConfig = {} } = args
+    const { url: requestUrl, options } = await flattenRequestInput(url, rawOptions)
     const config = { ...DEFAULT_RETRY_CONFIG, ...retryConfig }
     const { timeout, signal: userSignal, ...requestOptions } = options
     let lastError: Error | undefined
@@ -112,7 +163,7 @@ export async function fetchWithRetry(args: FetchWithRetryArgs): Promise<Response
             // the cast only reconciles undici's own Request/Response types with
             // the global lib types.
             const fetchImpl = (transport.fetch ?? fetch) as typeof fetch
-            const response = await fetchImpl(url, fetchOptions)
+            const response = await fetchImpl(requestUrl, fetchOptions)
             if (clearTimeoutFn) {
                 clearTimeoutFn()
             }

--- a/src/transport/http-dispatcher.test.ts
+++ b/src/transport/http-dispatcher.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { gzipSync } from 'node:zlib'
-import { Agent, EnvHttpProxyAgent } from 'undici'
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch } from 'undici'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { captureProxyEnv, clearProxyEnv, restoreProxyEnv } from '../_fixtures/proxy-env.js'
 
@@ -22,32 +22,43 @@ describe('http-dispatcher', () => {
     })
 
     it('returns a direct Agent when no proxy env vars are set', async () => {
-        const { getDefaultDispatcher } = await import('./http-dispatcher.js')
+        const { getDefaultTransport } = await import('./http-dispatcher.js')
 
-        expect(getDefaultDispatcher()).toBeInstanceOf(Agent)
+        expect(getDefaultTransport().dispatcher).toBeInstanceOf(Agent)
     })
 
     it('returns an EnvHttpProxyAgent when proxy env vars are set', async () => {
         process.env.HTTPS_PROXY = 'http://proxy.local:8080'
-        const { getDefaultDispatcher } = await import('./http-dispatcher.js')
+        const { getDefaultTransport } = await import('./http-dispatcher.js')
 
-        expect(getDefaultDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
+        expect(getDefaultTransport().dispatcher).toBeInstanceOf(EnvHttpProxyAgent)
     })
 
-    it('caches the dispatcher instance', async () => {
-        const { getDefaultDispatcher } = await import('./http-dispatcher.js')
+    it("pairs the dispatcher with undici's own fetch, not the global one", async () => {
+        const { getDefaultTransport } = await import('./http-dispatcher.js')
 
-        expect(getDefaultDispatcher()).toBe(getDefaultDispatcher())
+        // The dispatcher decompresses the body and strips `content-encoding`
+        // from the parsed headers only. Node's global `fetch` comes from a
+        // different undici build that reads the raw headers, so it decodes the
+        // body a second time and the request dies with `terminated`.
+        expect(getDefaultTransport().fetch).toBe(undiciFetch)
+        expect(getDefaultTransport().fetch).not.toBe(globalThis.fetch)
+    })
+
+    it('caches the transport instance', async () => {
+        const { getDefaultTransport } = await import('./http-dispatcher.js')
+
+        expect(getDefaultTransport()).toBe(getDefaultTransport())
     })
 
     it('reset lets tests re-evaluate env-dependent transport selection', async () => {
-        const { getDefaultDispatcher, resetDefaultDispatcherForTests } =
+        const { getDefaultTransport, resetDefaultDispatcherForTests } =
             await import('./http-dispatcher.js')
-        const directDispatcher = getDefaultDispatcher()
+        const directDispatcher = getDefaultTransport().dispatcher
 
         process.env.HTTPS_PROXY = 'http://proxy.local:8080'
         await resetDefaultDispatcherForTests()
-        const proxiedDispatcher = getDefaultDispatcher()
+        const proxiedDispatcher = getDefaultTransport().dispatcher
 
         expect(directDispatcher).toBeInstanceOf(Agent)
         expect(proxiedDispatcher).toBeInstanceOf(EnvHttpProxyAgent)
@@ -75,11 +86,15 @@ describe('http-dispatcher', () => {
         })
 
         try {
-            const { getDefaultDispatcher } = await import('./http-dispatcher.js')
-            const dispatcher = getDefaultDispatcher()
+            const { getDefaultTransport } = await import('./http-dispatcher.js')
+            const { dispatcher, fetch: pairedFetch } = getDefaultTransport()
 
             expect(dispatcher).toBeDefined()
             expect(typeof dispatcher.dispatch).toBe('function')
+            // Nothing decompresses on our side here, so the global `fetch` —
+            // which decompresses natively on such runtimes — is the correct
+            // partner, signalled by `fetch: undefined`.
+            expect(pairedFetch).toBeUndefined()
         } finally {
             // Leave `resetModules` to `afterEach`: it must reach this same
             // module instance to close the dispatcher created above before the
@@ -106,9 +121,13 @@ describe('http-dispatcher', () => {
 
         try {
             const { port } = httpServer.address() as AddressInfo
-            const { getDefaultDispatcher } = await import('./http-dispatcher.js')
-            const dispatcher = getDefaultDispatcher()
-            const response = await fetch(`http://127.0.0.1:${port}/`, {
+            const { getDefaultTransport } = await import('./http-dispatcher.js')
+            const { dispatcher, fetch: pairedFetch } = getDefaultTransport()
+            // Request through the paired `fetch`, which is what
+            // `fetchWithRetry` does — the global `fetch` with this dispatcher
+            // is the mismatched pairing production never uses.
+            const fetchImpl = (pairedFetch ?? fetch) as typeof fetch
+            const response = await fetchImpl(`http://127.0.0.1:${port}/`, {
                 // @ts-expect-error - dispatcher is a valid Node fetch option not in TS lib types
                 dispatcher,
             })
@@ -206,7 +225,7 @@ describe('http-dispatcher integration with decompress interceptor', () => {
                     decompress: () => {
                         // Simulate undici's experimental warning being emitted
                         // synchronously at compose time — this is the exact
-                        // shape `getDefaultDispatcher()` must suppress.
+                        // shape `getDefaultTransport()` must suppress.
                         process.emitWarning(
                             'mock decompress experimental warning',
                             'ExperimentalWarning',
@@ -217,8 +236,8 @@ describe('http-dispatcher integration with decompress interceptor', () => {
             }
         })
 
-        const { getDefaultDispatcher } = await import('./http-dispatcher.js')
-        const dispatcher = getDefaultDispatcher()
+        const { getDefaultTransport } = await import('./http-dispatcher.js')
+        const { dispatcher } = getDefaultTransport()
         expect(dispatcher).toBeDefined()
 
         const experimentalCalls = emitSpy.mock.calls.filter(

--- a/src/transport/http-dispatcher.ts
+++ b/src/transport/http-dispatcher.ts
@@ -1,4 +1,10 @@
-import { Agent, type Dispatcher, EnvHttpProxyAgent, interceptors } from 'undici'
+import {
+    Agent,
+    type Dispatcher,
+    EnvHttpProxyAgent,
+    fetch as undiciFetch,
+    interceptors,
+} from 'undici'
 
 const KEEP_ALIVE_OPTIONS = {
     keepAliveTimeout: 1,
@@ -7,7 +13,28 @@ const KEEP_ALIVE_OPTIONS = {
 
 const PROXY_ENV_KEYS = ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy'] as const
 
-let defaultDispatcher: Dispatcher | undefined
+// undici's own `fetch`, typed from the same package the dispatcher comes from.
+type UndiciFetch = typeof undiciFetch
+
+/**
+ * A dispatcher and the `fetch` it must be used with. `fetch` is undici's own
+ * `fetch` when the decompress interceptor is composed, or `undefined` (meaning:
+ * use the runtime's global `fetch`) on runtimes that ship a partial undici.
+ *
+ * The two halves are cached together so a caller can never hold a dispatcher
+ * paired with a mismatched `fetch`. The dispatcher decompresses the response
+ * body itself and strips `content-encoding` from the parsed headers only; a
+ * `fetch` from a different undici build reads the *raw* headers, still sees
+ * `content-encoding: gzip`, and decodes an already-decoded body — the request
+ * then dies mid-stream with `TypeError: terminated`. Node's global `fetch` is
+ * backed by whatever undici ships inside that Node release (6.x on Node 22 …
+ * 8.x on Node 26), which is never the npm `undici` this dispatcher comes from,
+ * so sourcing `fetch` from the same package keeps the whole request path on
+ * one version.
+ */
+export type DefaultTransport = { dispatcher: Dispatcher; fetch: UndiciFetch | undefined }
+
+let defaultTransport: DefaultTransport | undefined
 
 function hasProxyEnv(): boolean {
     for (const key of PROXY_ENV_KEYS) {
@@ -19,7 +46,7 @@ function hasProxyEnv(): boolean {
     return false
 }
 
-function createDefaultDispatcher(): Dispatcher {
+function createDefaultTransport(): DefaultTransport {
     const base = hasProxyEnv()
         ? new EnvHttpProxyAgent(KEEP_ALIVE_OPTIONS)
         : new Agent(KEEP_ALIVE_OPTIONS)
@@ -31,7 +58,9 @@ function createDefaultDispatcher(): Dispatcher {
     // skip the interceptor instead of crashing on the missing API. Optional
     // chaining also guards a runtime that omits the `interceptors` export.
     if (typeof interceptors?.decompress !== 'function') {
-        return base
+        // Nothing decompresses on our side, so the global `fetch` — which
+        // decompresses natively here — is the correct partner.
+        return { dispatcher: base, fetch: undefined }
     }
 
     // Compose the response-decompression interceptor so gzip/deflate/br/zstd
@@ -42,21 +71,31 @@ function createDefaultDispatcher(): Dispatcher {
     // See https://github.com/Doist/todoist-cli/issues/318.
     const decompress = suppressExperimentalWarningsSync(() => interceptors.decompress())
 
-    return base.compose(decompress)
+    return { dispatcher: base.compose(decompress), fetch: undiciFetch }
 }
 
-export function getDefaultDispatcher(): Dispatcher {
-    defaultDispatcher ??= createDefaultDispatcher()
-    return defaultDispatcher
+/**
+ * The default dispatcher and the `fetch` it must be used with, as a single
+ * value so the two are always read together. Use both halves:
+ *
+ * ```ts
+ * const transport = getDefaultTransport()
+ * const fetchImpl = transport.fetch ?? fetch
+ * await fetchImpl(url, { ...options, dispatcher: transport.dispatcher })
+ * ```
+ */
+export function getDefaultTransport(): DefaultTransport {
+    defaultTransport ??= createDefaultTransport()
+    return defaultTransport
 }
 
 export async function resetDefaultDispatcherForTests(): Promise<void> {
-    if (!defaultDispatcher) {
+    if (!defaultTransport) {
         return
     }
 
-    const dispatcher = defaultDispatcher
-    defaultDispatcher = undefined
+    const { dispatcher } = defaultTransport
+    defaultTransport = undefined
     await dispatcher.close()
 }
 
@@ -79,7 +118,7 @@ export async function resetDefaultDispatcherForTests(): Promise<void> {
 // that slips past the type check.
 //
 // Exported for direct unit testing — the integration path through
-// `getDefaultDispatcher()` cannot reliably exercise the helper a second time
+// `getDefaultTransport()` cannot reliably exercise the helper a second time
 // because both the dispatcher singleton and undici's internal `warningEmitted`
 // flag are once-per-process.
 type SyncOnly<T> = T extends PromiseLike<unknown> ? never : T


### PR DESCRIPTION
Bumps `undici` off 7.24.8 to clear two open advisories, and closes the gap that made that bump unsafe.

## Why the plain bump was not enough

undici 7.29.0 started setting `controller.rawHeaders`. Node 26's built-in fetch (undici 8.5) reads those raw headers in preference to the parsed ones. Our `decompress` interceptor strips `content-encoding` from the *parsed* headers only, so Node 26's fetch still sees `content-encoding: gzip` on a body the interceptor has already decompressed, decodes it a second time, and the request dies with `TypeError: terminated`.

`getDefaultDispatcher()` handed out half a pair, and `fetchWithRetry` combined it with the global `fetch` — exactly that mismatch. Measured here against a local server on real Node builds, through the built package:

| pairing | Node 22.22.2 | Node 24.18.0 | Node 26.4.0 |
| --- | --- | --- | --- |
| global `fetch` + our dispatcher (before) | OK | OK | **fails, all four encodings** |
| paired `fetch` + our dispatcher (after) | OK | OK | **OK** |

The Node 26 failures, verbatim: `terminated / incorrect header check` (gzip), `terminated / invalid distance too far back` (deflate), `terminated / Decompression failed` (br), `terminated / Unknown frame descriptor` (zstd).

## The fix

`getDefaultTransport()` replaces `getDefaultDispatcher()` and returns `{ dispatcher, fetch }` as a single value, so the two halves cannot be separated. `fetch` is undici's own where the decompress interceptor is composed, and `undefined` — meaning "use the global one" — on runtimes that ship a partial undici, where the global `fetch` decompresses natively and is the correct partner. `fetchWithRetry` reads both halves together.

Nothing outside `src/transport/` touched the dispatcher, and this package has no library entry point, so there is no deprecated shim to keep — the old export is gone.

## The bump

7.24.8 carries two open high advisories, both fixed in 7.29.0: [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (cookie attribute injection via unsanitized `domain`/`unparsed` in `setCookie`) and [GHSA-35p6-xmwp-9g52](https://github.com/advisories/GHSA-35p6-xmwp-9g52) (response queue poisoning via keep-alive socket reuse). `npm audit --omit=dev` goes from reporting both to reporting no undici findings.

`^7.29.0` rather than an exact pin, matching `@doist/todoist-sdk`: an exact pin means anyone behind a supply-chain scanner cannot resolve a patched version without an `overrides` entry. The caret keeps the major at 7 on purpose, and the renovate rule changes from `enabled: false` to `allowedVersions: "<8"` to hold that — an undici 8 dispatcher hangs indefinitely against Node 24's built-in fetch.

## Verification

- Encoding matrix above: gzip, deflate, br and zstd through the built `fetchWithRetry` on Node 22.22.2, 24.18.0 and 26.4.0, against a local server, no mocks. The same script drives the old mismatched pairing side by side, which is where the failures above come from.
- `npm test` green on Node 22 and Node 26 — 227 tests, five of them new: one pinning that the transport hands back undici's `fetch` and not the global one, one that `fetchWithRetry` uses the paired `fetch` in preference to the global one, and three covering `Request` inputs (see the follow-up below).
- The gzip integration test now requests through the paired `fetch`. It previously used the global `fetch` with our dispatcher — the pairing production never uses, and the one that hides this bug.
- Live smoke on Node 26: `ol collection list --json` against a real Outline instance returns decoded JSON.

Mirrors Doist/todoist-sdk-typescript#674, which found this and fixed it in the SDK.


## Note

Touches `renovate.json`, as does #91. Different rules in the same array, so whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xoHmYxj4bbWRNFTZjvEci
